### PR TITLE
Implement isRecordCVar builtin for Browser

### DIFF
--- a/src/org/mozartoz/truffle/nodes/builtins/BrowserBuiltins.java
+++ b/src/org/mozartoz/truffle/nodes/builtins/BrowserBuiltins.java
@@ -1,8 +1,11 @@
 package org.mozartoz.truffle.nodes.builtins;
 
 import org.mozartoz.truffle.nodes.OzNode;
+import org.mozartoz.truffle.nodes.builtins.RecordBuiltins.IsRecordNode;
 import org.mozartoz.truffle.runtime.OzVar;
+import org.mozartoz.truffle.runtime.Variable;
 
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
@@ -10,15 +13,21 @@ import com.oracle.truffle.api.dsl.Specialization;
 
 public abstract class BrowserBuiltins {
 
+	@Builtin(tryDeref = 1)
 	@GenerateNodeFactory
 	@NodeChild("value")
 	public static abstract class IsRecordCVarNode extends OzNode {
 
-		@Specialization
-		Object isRecordCVar(Object value) {
-			return unimplemented();
+		@Specialization(guards = "!isVariable(value)")
+		boolean isRecordCVar(Object value,
+				@Cached("create()") IsRecordNode isRecordNode) {
+			return isRecordNode.executeIsRecord(value);
 		}
 
+		boolean isRecordCVar(Variable var) {
+			// thanks to tryDeref, we know var is unbound
+			return false;
+		}
 	}
 
 	@GenerateNodeFactory

--- a/src/org/mozartoz/truffle/nodes/builtins/RecordBuiltins.java
+++ b/src/org/mozartoz/truffle/nodes/builtins/RecordBuiltins.java
@@ -9,6 +9,7 @@ import org.mozartoz.truffle.nodes.DerefIfBoundNode;
 import org.mozartoz.truffle.nodes.DerefIfBoundNodeGen;
 import org.mozartoz.truffle.nodes.OzGuards;
 import org.mozartoz.truffle.nodes.OzNode;
+import org.mozartoz.truffle.nodes.builtins.RecordBuiltinsFactory.IsRecordNodeFactory;
 import org.mozartoz.truffle.nodes.builtins.RecordBuiltinsFactory.LabelNodeFactory;
 import org.mozartoz.truffle.runtime.Arity;
 import org.mozartoz.truffle.runtime.OzCons;
@@ -33,6 +34,12 @@ public abstract class RecordBuiltins {
 	@GenerateNodeFactory
 	@NodeChild("value")
 	public static abstract class IsRecordNode extends OzNode {
+
+		public static IsRecordNode create() {
+			return IsRecordNodeFactory.create(null);
+		}
+
+		public abstract boolean executeIsRecord(Object record);
 
 		@Specialization
 		boolean isRecord(String atom) {


### PR DESCRIPTION
The following code now works:

``` oz
functor
import
   Browser
define
   {Browser.browse 42}
   {Browser.browse a(b:c d:[1 2 3])}

   S
   P={NewPort S}
   {Browser.browse S}
   for I in {List.number 1 10 1} do
      {Delay 1000}
      {Send P I}
   end

   {Delay 3*60*1000}
end
```
