### PR TITLE
Every procedure should be candidate to tail call optimization

### DIFF
--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TailCallMarking.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TailCallMarking.scala
@@ -6,36 +6,36 @@ import oz._
 import symtab._
 
 object TailCallMarking extends Transformer {
-  def markTailCalls(name: Symbol, statement: Statement): Statement = statement match {
+  def markTailCalls(statement: Statement): Statement = statement match {
     case call @ CallStatement(callable, args) =>
       treeCopy.TailMarkerStatement(statement, call)
 
     case CompoundStatement(stats) =>
-      val last = markTailCalls(name, stats.last)
+      val last = markTailCalls(stats.last)
       treeCopy.CompoundStatement(statement, stats.dropRight(1) :+ last)
       
-    case IfStatement(condition, trueExpression, falseExpression) =>
+    case IfStatement(condition, trueStatement, falseStatement) =>
       treeCopy.IfStatement(statement, condition,
-          markTailCalls(name, trueExpression),
-          markTailCalls(name, falseExpression))
+          markTailCalls(trueStatement),
+          markTailCalls(falseStatement))
           
     case MatchStatement(value, clauses, elseStatement) =>
       treeCopy.MatchStatement(statement, value,
-          clauses.map(c => markMatchStatementClause(name, c)),
-          markTailCalls(name, elseStatement))
+          clauses.map(c => markMatchStatementClause(c)),
+          markTailCalls(elseStatement))
       
     case LocalStatement(declarations, stat) =>
-      treeCopy.LocalStatement(statement, declarations, markTailCalls(name, stat))
+      treeCopy.LocalStatement(statement, declarations, markTailCalls(stat))
       
     case _ => statement
   }
   
-  def markMatchStatementClause(name: Symbol, clause: MatchStatementClause) =
-    treeCopy.MatchStatementClause(clause, clause.pattern, clause.guard, markTailCalls(name, clause.body))
+  def markMatchStatementClause(clause: MatchStatementClause) =
+    treeCopy.MatchStatementClause(clause, clause.pattern, clause.guard, markTailCalls(clause.body))
   
   override def transformExpr(expression: Expression) = expression match {
-    case ProcExpression(name @ Some(Variable(sym)), args, body, flags) =>
-      treeCopy.ProcExpression(expression, name, args, markTailCalls(sym, transformStat(body)), flags)
+    case ProcExpression(name, args, body, flags) =>
+      treeCopy.ProcExpression(expression, name, args, markTailCalls(transformStat(body)), flags)
     
     case _ => super.transformExpr(expression)
   }


### PR DESCRIPTION
The TailCallMarker did not optimize anonymous procedures.