### PR TITLE
Rewrite Int.toFloat to use JVM primitives

### DIFF
--- a/lib/main/base/Base.oz
+++ b/lib/main/base/Base.oz
@@ -174,7 +174,7 @@ prepare
    %% Int
    %%
    IsInt              = Boot_Int.is
-   IntToFloat         % Defined in Int.oz
+   IntToFloat         = Boot_Int.toFloat
    IntToCompactString % Defined in Int.oz
    IntToString        % Defined in Int.oz
 

--- a/lib/main/base/Int.oz
+++ b/lib/main/base/Int.oz
@@ -34,10 +34,6 @@ fun {IsEven X} X mod 2 == 0 end
 %%
 %% Module
 %%
-fun {IntToFloat I}
-   {StringToFloat {IntToCompactString I}}
-end
-
 fun {IntToCompactString I}
    if {IsInt I} then
       {VirtualString.toCompactString I}

--- a/vm/src/org/mozartoz/truffle/nodes/builtins/IntBuiltins.java
+++ b/vm/src/org/mozartoz/truffle/nodes/builtins/IntBuiltins.java
@@ -35,6 +35,23 @@ public abstract class IntBuiltins {
 
 	}
 
+	@Builtin(name = "toFloat", deref = ALL)
+	@GenerateNodeFactory
+	@NodeChild("value")
+	public static abstract class ToFloatNode extends OzNode {
+
+		@Specialization
+		double toFloat(long value) {
+			return (double) value;
+		}
+
+		@Specialization
+		double toFloat(BigInteger value) {
+			return value.doubleValue();
+		}
+
+	}
+
 	@Builtin(deref = ALL)
 	@GenerateNodeFactory
 	@NodeChildren({ @NodeChild("left"), @NodeChild("right") })


### PR DESCRIPTION
Everything is in the title! :p
It previously converted Int to String, and String to Float.