### PR TITLE
Optimize IntPow for constant exponents

### DIFF
--- a/lib/main/base/Base.oz
+++ b/lib/main/base/Base.oz
@@ -204,7 +204,7 @@ prepare
    %%
    IsNumber = Boot_Number.is
    Abs      = Boot_Number.abs
-   Pow      % Defined in Number.oz
+   Pow      = Boot_Number.pow
 
    %%
    %% Tuple

--- a/lib/main/base/Number.oz
+++ b/lib/main/base/Number.oz
@@ -27,23 +27,6 @@
 %% Global
 %%
 
-local
-   FloatPow = Boot_Float.pow
-   fun {IntPow X N A}
-      if N==0 then A
-      elseif N mod 2==0 then {IntPow X*X (N div 2) A}
-      else {IntPow X (N-1) A*X}
-      end
-   end
-in
-   fun {Pow X Y}
-      case ({IsInt X} andthen {IsInt Y}) of true then
-	 if Y>0 then {IntPow X Y 1} else Y=0 1 end
-      elsecase ({IsFloat X} andthen {IsFloat Y}) of true then {FloatPow X Y}
-      end
-   end
-end
-
 
 %%
 %% Module

--- a/oz
+++ b/oz
@@ -53,6 +53,12 @@ if vm_options.delete('--igv')
   java_opts << "-Dgraal.TruffleBackgroundCompilation=false"
 end
 
+if vm_options.delete('--igvcfg')
+  java_opts << "-Dgraal.Dump="
+  java_opts << "-Dgraal.PrintBackendCFG=true"
+  java_opts << "-Dgraal.TruffleBackgroundCompilation=false"
+end
+
 if vm_options.delete('--infopoints')
   java_opts << "-XX:+UnlockDiagnosticVMOptions" << "-XX:+DebugNonSafepoints"
   java_opts << "-Dgraal.TruffleEnableInfopoints=true"

--- a/vm/src/org/mozartoz/truffle/nodes/OzGuards.java
+++ b/vm/src/org/mozartoz/truffle/nodes/OzGuards.java
@@ -27,6 +27,10 @@ public class OzGuards {
 		return value instanceof BigInteger;
 	}
 
+	public static boolean isInteger(Object value) {
+		return value instanceof Long || value instanceof BigInteger;
+	}
+
 	public static boolean isFloat(Object value) {
 		return value instanceof Double;
 	}

--- a/vm/src/org/mozartoz/truffle/nodes/builtins/FloatBuiltins.java
+++ b/vm/src/org/mozartoz/truffle/nodes/builtins/FloatBuiltins.java
@@ -42,18 +42,6 @@ public abstract class FloatBuiltins {
 
 	@Builtin(deref = ALL)
 	@GenerateNodeFactory
-	@NodeChildren({ @NodeChild("left"), @NodeChild("right") })
-	public static abstract class PowNode extends OzNode {
-
-		@Specialization
-		double pow(double left, double right) {
-			return Math.pow(left, right);
-		}
-
-	}
-
-	@Builtin(deref = ALL)
-	@GenerateNodeFactory
 	@NodeChild("value")
 	public static abstract class ToIntNode extends OzNode {
 


### PR DESCRIPTION
Added an the --igvcfg option to be able to follow the whole JIT compilation process.

Also rewrote the Pow builtin in Java in order to optimize calls on constant powers. The limit on the exponent is the limit to have at max 11 unrolled nodes. Note we could also have a specialization for bases that would be powers of 2, but the use cases seem much more restricted.