### PR TITLE
Add self tailcall optimization

### DIFF
--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Statements.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Statements.scala
@@ -59,7 +59,11 @@ case class LocalStatement(declarations: Seq[Variable],
 case class CallStatement(callable: Expression,
     args: Seq[Expression])(val pos: Pos) extends Statement with CallCommon
     
-case class TailMarkerStatement(call: CallStatement)(val pos: Pos) extends Statement {
+case class TailCallMarker(call: CallStatement)(val pos: Pos) extends Statement {
+  override def syntax(indent: String) = call.syntax(indent)
+}
+
+case class SelfTailCallMarker(call: CallStatement)(val pos: Pos) extends Statement {
   override def syntax(indent: String) = call.syntax(indent)
 }
 

--- a/vm/src/org/mozartoz/truffle/Options.java
+++ b/vm/src/org/mozartoz/truffle/Options.java
@@ -12,6 +12,9 @@ public abstract class Options {
 
 	public static final boolean TAIL_CALLS = bool("oz.tail.calls", true);
 
+	public static final boolean SELF_TAIL_CALLS = bool("oz.tail.selfcalls", true);
+	public static final boolean SELF_TAIL_CALLS_OSR = bool("oz.tail.selfcalls.osr", true);
+
 	public static final boolean STACKTRACE_ON_INTERRUPT = System.getProperty("oz.stacktrace.on_interrupt") != null;
 
 	private static boolean bool(String property, boolean defaultValue) {

--- a/vm/src/org/mozartoz/truffle/nodes/call/SelfTailCallCatcherNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/call/SelfTailCallCatcherNode.java
@@ -1,0 +1,86 @@
+package org.mozartoz.truffle.nodes.call;
+
+import org.mozartoz.truffle.Options;
+import org.mozartoz.truffle.nodes.OzNode;
+import org.mozartoz.truffle.runtime.OzBacktrace;
+import org.mozartoz.truffle.runtime.SelfTailCallException;
+
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.LoopNode;
+import com.oracle.truffle.api.nodes.RepeatingNode;
+
+public class SelfTailCallCatcherNode extends OzNode {
+
+	OzNode body; // For serialization compliance
+	@Child LoopNode loopNode;
+
+	public SelfTailCallCatcherNode(OzNode body) {
+		this.body = body;
+		this.loopNode = Truffle.getRuntime().createLoopNode(new SelfTailCallLoopNode(body));
+	}
+
+	public static OzNode create(OzNode body) {
+		if (!Options.SELF_TAIL_CALLS_OSR) {
+			return new SelfTailCallCatcherNode.SelfTailCallCatcherNoOSRNode(body);
+		}
+		return new SelfTailCallCatcherNode(body);
+	}
+
+	@Override
+	public Object execute(VirtualFrame frame) {
+		loopNode.executeLoop(frame);
+		return unit;
+	}
+
+	public static class SelfTailCallLoopNode extends OzNode implements RepeatingNode {
+
+		@Child OzNode body;
+
+		public SelfTailCallLoopNode(OzNode body) {
+			this.body = body;
+		}
+
+		@Override
+		public boolean executeRepeating(VirtualFrame frame) {
+			try {
+				body.execute(frame);
+				return false;
+			} catch (SelfTailCallException e) {
+				return true;
+			}
+		}
+
+		@Override
+		public Object execute(VirtualFrame frame) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String toString() {
+			return OzBacktrace.formatNode(this);
+		}
+
+	}
+
+	public static class SelfTailCallCatcherNoOSRNode extends OzNode {
+
+		@Child OzNode body;
+
+		public SelfTailCallCatcherNoOSRNode(OzNode body) {
+			this.body = body;
+		}
+
+		@Override
+		public Object execute(VirtualFrame frame) {
+			while (true) {
+				try {
+					return body.execute(frame);
+				} catch (SelfTailCallException tailCall) {
+				}
+			}
+		}
+
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/nodes/call/SelfTailCallThrowerNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/call/SelfTailCallThrowerNode.java
@@ -1,0 +1,30 @@
+package org.mozartoz.truffle.nodes.call;
+
+import org.mozartoz.truffle.nodes.OzNode;
+import org.mozartoz.truffle.runtime.OzArguments;
+import org.mozartoz.truffle.runtime.SelfTailCallException;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+
+public class SelfTailCallThrowerNode extends OzNode {
+
+	@Children final OzNode[] arguments;
+
+	public SelfTailCallThrowerNode(OzNode[] arguments) {
+		this.arguments = arguments;
+	}
+
+	public Object execute(VirtualFrame frame) {
+		replaceArguments(frame);
+		throw SelfTailCallException.INSTANCE;
+	}
+
+	@ExplodeLoop
+	public void replaceArguments(VirtualFrame frame) {
+		for (int i = 0; i < arguments.length; i++) {
+			OzArguments.setArgument(frame, i, arguments[i].execute(frame));
+		}
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/runtime/OzArguments.java
+++ b/vm/src/org/mozartoz/truffle/runtime/OzArguments.java
@@ -25,6 +25,10 @@ public class OzArguments {
 		return frame.getArguments()[ARGUMENTS_INDEX + index];
 	}
 
+	public static void setArgument(Frame frame, int index, Object value) {
+		frame.getArguments()[ARGUMENTS_INDEX + index] = value;
+	}
+
 	public static int getArgumentCount(Frame frame) {
 		return frame.getArguments().length - ARGUMENTS_INDEX;
 	}

--- a/vm/src/org/mozartoz/truffle/runtime/SelfTailCallException.java
+++ b/vm/src/org/mozartoz/truffle/runtime/SelfTailCallException.java
@@ -1,0 +1,13 @@
+package org.mozartoz.truffle.runtime;
+
+import com.oracle.truffle.api.nodes.ControlFlowException;
+
+public class SelfTailCallException extends ControlFlowException {
+
+	private static final long serialVersionUID = -6432472909387052509L;
+	public static final SelfTailCallException INSTANCE = new SelfTailCallException();
+
+	private SelfTailCallException() {
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/translator/OzSerializer.java
+++ b/vm/src/org/mozartoz/truffle/translator/OzSerializer.java
@@ -45,6 +45,8 @@ import org.mozartoz.truffle.nodes.call.CallMethodNodeGen;
 import org.mozartoz.truffle.nodes.call.CallNodeGen;
 import org.mozartoz.truffle.nodes.call.CallProcNodeGen;
 import org.mozartoz.truffle.nodes.call.ReadArgumentNode;
+import org.mozartoz.truffle.nodes.call.SelfTailCallCatcherNode;
+import org.mozartoz.truffle.nodes.call.SelfTailCallThrowerNode;
 import org.mozartoz.truffle.nodes.call.TailCallCatcherNode;
 import org.mozartoz.truffle.nodes.call.TailCallThrowerNode;
 import org.mozartoz.truffle.nodes.control.AndNode;
@@ -683,6 +685,9 @@ public class OzSerializer implements AutoCloseable {
 		kryo.register(CallMethodNodeGen.class);
 		kryo.register(TailCallCatcherNode.class);
 		kryo.register(TailCallThrowerNode.class);
+		kryo.register(SelfTailCallCatcherNode.class);
+		kryo.register(SelfTailCallCatcherNode.SelfTailCallCatcherNoOSRNode.class);
+		kryo.register(SelfTailCallThrowerNode.class);
 
 		kryo.register(ReadLocalVariableNode.class);
 		kryo.register(ReadCapturedVariableNode.class);


### PR DESCRIPTION
Added this optimization for 2 reasons:

- Basically, it makes self tail recursion lighter for the interpreter in useful cases.
- As you told me, Graal is not able to detect the TailCallException does not escape with the current OSR mechanism, so it does not reach as efficient solutions as it could theoretically. This is a case where we can help him, let's do it.

I have benchmarked with and without self tailcall optimization. Some curves are available there to assess it should perform better.
https://github.com/mistasse/mozart-graal-benchmarking/blob/a3edd543a0a1c5e6bcbb6e6d1eaf06036a383c03/notebook.ipynb