### PR TITLE
Unlink variables on binding

### DIFF
--- a/vm/src/org/mozartoz/truffle/Options.java
+++ b/vm/src/org/mozartoz/truffle/Options.java
@@ -16,8 +16,8 @@ public abstract class Options {
 	public static final boolean SELF_TAIL_CALLS_OSR = bool("oz.tail.selfcalls.osr", true);
 
 	public static final boolean STACKTRACE_ON_INTERRUPT = System.getProperty("oz.stacktrace.on_interrupt") != null;
-	public static final String PRINT_NLINKS = System.getProperty("oz.print.nlinks", null);
 
+	public static final boolean PRINT_NLINKS = bool("oz.print.nlinks", false);
 	public static final boolean FREE_LINKS = bool("oz.free.links", true);
 
 	// Truffle options

--- a/vm/src/org/mozartoz/truffle/Options.java
+++ b/vm/src/org/mozartoz/truffle/Options.java
@@ -18,6 +18,8 @@ public abstract class Options {
 	public static final boolean STACKTRACE_ON_INTERRUPT = System.getProperty("oz.stacktrace.on_interrupt") != null;
 	public static final String PRINT_NLINKS = System.getProperty("oz.print.nlinks", null);
 
+	public static final boolean FREE_LINKS = bool("oz.free.links", true);
+
 	// Truffle options
 	public static final int TruffleInvalidationReprofileCount = integer("graal.TruffleInvalidationReprofileCount", 3);
 	public static final int TruffleOSRCompilationThreshold = integer("graal.TruffleOSRCompilationThreshold", 100_000);

--- a/vm/src/org/mozartoz/truffle/Options.java
+++ b/vm/src/org/mozartoz/truffle/Options.java
@@ -16,6 +16,7 @@ public abstract class Options {
 	public static final boolean SELF_TAIL_CALLS_OSR = bool("oz.tail.selfcalls.osr", true);
 
 	public static final boolean STACKTRACE_ON_INTERRUPT = System.getProperty("oz.stacktrace.on_interrupt") != null;
+	public static final String PRINT_NLINKS = System.getProperty("oz.print.nlinks", null);
 
 	// Truffle options
 	public static final int TruffleInvalidationReprofileCount = integer("graal.TruffleInvalidationReprofileCount", 3);

--- a/vm/src/org/mozartoz/truffle/Options.java
+++ b/vm/src/org/mozartoz/truffle/Options.java
@@ -17,15 +17,21 @@ public abstract class Options {
 
 	public static final boolean STACKTRACE_ON_INTERRUPT = System.getProperty("oz.stacktrace.on_interrupt") != null;
 
-	public static final boolean PRINT_NLINKS = bool("oz.print.nlinks", false);
 	public static final boolean FREE_LINKS = bool("oz.free.links", true);
+	public static final boolean PRINT_NLINKS = bool("oz.print.nlinks", false);
 
 	// Truffle options
 	public static final int TruffleInvalidationReprofileCount = integer("graal.TruffleInvalidationReprofileCount", 3);
 	public static final int TruffleOSRCompilationThreshold = integer("graal.TruffleOSRCompilationThreshold", 100_000);
 
 	private static boolean bool(String property, boolean defaultValue) {
-		return Boolean.valueOf(System.getProperty(property, Boolean.toString(defaultValue)));
+		String value = System.getProperty(property, Boolean.toString(defaultValue));
+		if (value.equalsIgnoreCase("true")) {
+			return true;
+		} else if (value.equalsIgnoreCase("false")) {
+			return false;
+		}
+		throw new RuntimeException(property + " was expected to be true or false, got " + value);
 	}
 
 	private static int integer(String property, int defaultValue) {

--- a/vm/src/org/mozartoz/truffle/nodes/control/ForNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/control/ForNode.java
@@ -1,5 +1,6 @@
 package org.mozartoz.truffle.nodes.control;
 
+import org.mozartoz.truffle.nodes.DerefNode;
 import org.mozartoz.truffle.nodes.OzNode;
 import org.mozartoz.truffle.nodes.call.CallNode;
 import org.mozartoz.truffle.nodes.call.CallableNode;
@@ -16,6 +17,9 @@ public class ForNode extends OzNode {
 	@Child OzNode toNode;
 	@Child OzNode procNode;
 
+	@Child DerefNode fromDerefNode = DerefNode.create();
+	@Child DerefNode toDerefNode = DerefNode.create();
+
 	@Child CallableNode callNode = CallNode.create(null, null);
 	private final LoopConditionProfile loopProfile = LoopConditionProfile.createCountingProfile();
 
@@ -27,8 +31,8 @@ public class ForNode extends OzNode {
 
 	@Override
 	public Object execute(VirtualFrame frame) {
-		long from = (long) fromNode.execute(frame);
-		long to = (long) toNode.execute(frame);
+		long from = (long) fromDerefNode.executeDeref(fromNode.execute(frame));
+		long to = (long) toDerefNode.executeDeref(toNode.execute(frame));
 
 		int count = 0;
 		if (CompilerDirectives.inInterpreter()) {

--- a/vm/src/org/mozartoz/truffle/nodes/local/BindVarValueNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/BindVarValueNode.java
@@ -37,8 +37,9 @@ public abstract class BindVarValueNode extends OzNode {
 	@Specialization(guards = { "var.getNext() != var", "var.getNext().getNext().getNext() == var" })
 	Object bind3(Variable var, Object value) {
 		print_nlinks(var);
-		Variable next1 = var.getNext(), next2 = next1.getNext();
+		Variable next1 = var.getNext();
 		var.setInternalValue(value, var);
+		Variable next2 = next1.getNext();
 		next1.setInternalValue(value, var);
 		next2.setInternalValue(value, var);
 		return value;
@@ -52,14 +53,14 @@ public abstract class BindVarValueNode extends OzNode {
 	}
 
 	public static void print_nlinks(Variable var) {
-		if (Options.PRINT_NLINKS != null) {
+		if (Options.PRINT_NLINKS) {
 			int count = 1;
 			Variable current = var.getNext();
 			while (current != var) {
 				count += 1;
 				current = current.getNext();
 			}
-			System.out.println(Options.PRINT_NLINKS + " --- " + count);
+			System.out.println("nlinks --- " + count);
 		}
 	}
 

--- a/vm/src/org/mozartoz/truffle/nodes/local/BindVarValueNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/BindVarValueNode.java
@@ -1,5 +1,6 @@
 package org.mozartoz.truffle.nodes.local;
 
+import org.mozartoz.truffle.Options;
 import org.mozartoz.truffle.nodes.OzNode;
 import org.mozartoz.truffle.runtime.OzVar;
 import org.mozartoz.truffle.runtime.Variable;
@@ -19,30 +20,47 @@ public abstract class BindVarValueNode extends OzNode {
 
 	@Specialization(guards = "var.getNext() == var")
 	Object bind1(Variable var, Object value) {
+		print_nlinks(var);
 		var.setInternalValue(value, var);
 		return value;
 	}
 
 	@Specialization(guards = { "var.getNext() != var", "var.getNext().getNext() == var" })
 	Object bind2(Variable var, Object value) {
+		print_nlinks(var);
+		Variable next = var.getNext();
 		var.setInternalValue(value, var);
-		var.getNext().setInternalValue(value, var);
+		next.setInternalValue(value, var);
 		return value;
 	}
 
 	@Specialization(guards = { "var.getNext() != var", "var.getNext().getNext().getNext() == var" })
 	Object bind3(Variable var, Object value) {
+		print_nlinks(var);
+		Variable next1 = var.getNext(), next2 = next1.getNext();
 		var.setInternalValue(value, var);
-		Variable next = var.getNext();
-		next.setInternalValue(value, var);
-		next.getNext().setInternalValue(value, var);
+		next1.setInternalValue(value, var);
+		next2.setInternalValue(value, var);
 		return value;
 	}
 
 	@Specialization(contains = { "bind1", "bind2", "bind3" })
 	Object bindLeft(OzVar var, Object value) {
+		print_nlinks(var);
 		var.bind(value);
 		return value;
+	}
+
+	public static void print_nlinks(Variable var) {
+		if (Options.PRINT_NLINKS != null) {
+			int count = 1;
+			Variable current = var.getNext();
+			while (current != var) {
+				count += 1;
+				current = current.getNext();
+			}
+			System.out.println(Options.PRINT_NLINKS + " --- " + count);
+		}
 	}
 
 }

--- a/vm/src/org/mozartoz/truffle/nodes/local/BindVarValueNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/BindVarValueNode.java
@@ -1,6 +1,5 @@
 package org.mozartoz.truffle.nodes.local;
 
-import org.mozartoz.truffle.Options;
 import org.mozartoz.truffle.nodes.OzNode;
 import org.mozartoz.truffle.runtime.OzVar;
 import org.mozartoz.truffle.runtime.Variable;
@@ -20,14 +19,14 @@ public abstract class BindVarValueNode extends OzNode {
 
 	@Specialization(guards = "var.getNext() == var")
 	Object bind1(Variable var, Object value) {
-		print_nlinks(var);
+		var.countLinks();
 		var.setInternalValue(value, var);
 		return value;
 	}
 
 	@Specialization(guards = { "var.getNext() != var", "var.getNext().getNext() == var" })
 	Object bind2(Variable var, Object value) {
-		print_nlinks(var);
+		var.countLinks();
 		Variable next = var.getNext();
 		var.setInternalValue(value, var);
 		next.setInternalValue(value, var);
@@ -36,7 +35,7 @@ public abstract class BindVarValueNode extends OzNode {
 
 	@Specialization(guards = { "var.getNext() != var", "var.getNext().getNext().getNext() == var" })
 	Object bind3(Variable var, Object value) {
-		print_nlinks(var);
+		var.countLinks();
 		Variable next1 = var.getNext();
 		var.setInternalValue(value, var);
 		Variable next2 = next1.getNext();
@@ -47,21 +46,9 @@ public abstract class BindVarValueNode extends OzNode {
 
 	@Specialization(contains = { "bind1", "bind2", "bind3" })
 	Object bindLeft(OzVar var, Object value) {
-		print_nlinks(var);
+		var.countLinks();
 		var.bind(value);
 		return value;
-	}
-
-	public static void print_nlinks(Variable var) {
-		if (Options.PRINT_NLINKS) {
-			int count = 1;
-			Variable current = var.getNext();
-			while (current != var) {
-				count += 1;
-				current = current.getNext();
-			}
-			System.out.println("nlinks --- " + count);
-		}
 	}
 
 }

--- a/vm/src/org/mozartoz/truffle/nodes/local/BindVarValueNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/BindVarValueNode.java
@@ -1,5 +1,6 @@
 package org.mozartoz.truffle.nodes.local;
 
+import org.mozartoz.truffle.Options;
 import org.mozartoz.truffle.nodes.OzNode;
 import org.mozartoz.truffle.runtime.OzVar;
 import org.mozartoz.truffle.runtime.Variable;
@@ -19,14 +20,14 @@ public abstract class BindVarValueNode extends OzNode {
 
 	@Specialization(guards = "var.getNext() == var")
 	Object bind1(Variable var, Object value) {
-		var.countLinks();
+		printNLinks(var);
 		var.setInternalValue(value, var);
 		return value;
 	}
 
 	@Specialization(guards = { "var.getNext() != var", "var.getNext().getNext() == var" })
 	Object bind2(Variable var, Object value) {
-		var.countLinks();
+		printNLinks(var);
 		Variable next = var.getNext();
 		var.setInternalValue(value, var);
 		next.setInternalValue(value, var);
@@ -35,7 +36,7 @@ public abstract class BindVarValueNode extends OzNode {
 
 	@Specialization(guards = { "var.getNext() != var", "var.getNext().getNext().getNext() == var" })
 	Object bind3(Variable var, Object value) {
-		var.countLinks();
+		printNLinks(var);
 		Variable next1 = var.getNext();
 		var.setInternalValue(value, var);
 		Variable next2 = next1.getNext();
@@ -46,9 +47,15 @@ public abstract class BindVarValueNode extends OzNode {
 
 	@Specialization(contains = { "bind1", "bind2", "bind3" })
 	Object bindLeft(OzVar var, Object value) {
-		var.countLinks();
+		printNLinks(var);
 		var.bind(value);
 		return value;
+	}
+
+	public static void printNLinks(Variable var) {
+		if (Options.PRINT_NLINKS) {
+			System.out.println("nlinks --- " + var.countLinks());
+		}
 	}
 
 }

--- a/vm/src/org/mozartoz/truffle/runtime/Variable.java
+++ b/vm/src/org/mozartoz/truffle/runtime/Variable.java
@@ -59,14 +59,15 @@ public abstract class Variable {
 		assert !(this instanceof OzFuture) || from instanceof OzFuture;
 		this.value = value;
 		if (Options.FREE_LINKS) {
-			this.next = null; // Set to null or to this?
+			this.next = null; // null to catch wrong usages
 		}
 	}
 
 	public void bind(Object value) {
-		Variable var = this.next, next;
+		Variable var = this.next;
 		setInternalValue(value, this);
 
+		Variable next;
 		while (var != this) {
 			next = var.next;
 			var.setInternalValue(value, this);

--- a/vm/src/org/mozartoz/truffle/runtime/Variable.java
+++ b/vm/src/org/mozartoz/truffle/runtime/Variable.java
@@ -57,15 +57,17 @@ public abstract class Variable {
 		assert !(value instanceof Variable);
 		assert !(this instanceof OzFuture) || from instanceof OzFuture;
 		this.value = value;
+		this.next = null; // Set to null or to this?
 	}
 
 	public void bind(Object value) {
+		Variable var = this.next, next;
 		setInternalValue(value, this);
 
-		Variable var = next;
 		while (var != this) {
+			next = var.next;
 			var.setInternalValue(value, this);
-			var = var.next;
+			var = next;
 		}
 	}
 

--- a/vm/src/org/mozartoz/truffle/runtime/Variable.java
+++ b/vm/src/org/mozartoz/truffle/runtime/Variable.java
@@ -1,5 +1,6 @@
 package org.mozartoz.truffle.runtime;
 
+import org.mozartoz.truffle.Options;
 import org.mozartoz.truffle.nodes.OzNode;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
@@ -57,7 +58,9 @@ public abstract class Variable {
 		assert !(value instanceof Variable);
 		assert !(this instanceof OzFuture) || from instanceof OzFuture;
 		this.value = value;
-		this.next = null; // Set to null or to this?
+		if (Options.FREE_LINKS) {
+			this.next = null; // Set to null or to this?
+		}
 	}
 
 	public void bind(Object value) {

--- a/vm/src/org/mozartoz/truffle/runtime/Variable.java
+++ b/vm/src/org/mozartoz/truffle/runtime/Variable.java
@@ -104,16 +104,14 @@ public abstract class Variable {
 		return getBoundValue(currentNode);
 	}
 
-	public void countLinks() {
-		if (Options.PRINT_NLINKS) {
-			int count = 1;
-			Variable current = this.getNext();
-			while (current != this) {
-				count += 1;
-				current = current.getNext();
-			}
-			System.out.println("nlinks --- " + count);
+	public int countLinks() {
+		int count = 1;
+		Variable current = this.getNext();
+		while (current != this) {
+			count += 1;
+			current = current.getNext();
 		}
+		return count;
 	}
 
 	@Override

--- a/vm/src/org/mozartoz/truffle/runtime/Variable.java
+++ b/vm/src/org/mozartoz/truffle/runtime/Variable.java
@@ -104,6 +104,18 @@ public abstract class Variable {
 		return getBoundValue(currentNode);
 	}
 
+	public void countLinks() {
+		if (Options.PRINT_NLINKS) {
+			int count = 1;
+			Variable current = this.getNext();
+			while (current != this) {
+				count += 1;
+				current = current.getNext();
+			}
+			System.out.println("nlinks --- " + count);
+		}
+	}
+
 	@Override
 	public abstract String toString();
 


### PR DESCRIPTION
This PR is mostly about unlinking variables when they are unified with a variable, in order to avoid chains of variables to be kept in memory.

I added an option in order to estimate its impact on benchmarks (mostly the project), and it seems legitimate though I do not fully understand how it can yield such difference.

The dereference on for nodes is useful in order to run benchmarks by hand for instance. Because for now, the programs only worked when modified by the benchmark tool.