### PR TITLE
Handle cyclic data structures in unification, equality test, pattern …

### DIFF
--- a/platform-test/base/unification.oz
+++ b/platform-test/base/unification.oz
@@ -1,0 +1,106 @@
+functor
+import
+   System(show:Show)
+export
+   Return
+define
+   ShouldHaveFailed = 'should have failed'
+   proc{MustFail X P}
+      skip
+      try
+         {P}
+         raise ShouldHaveFailed end
+      catch S then case S of !ShouldHaveFailed then
+         raise '  '(X ShouldHaveFailed) end
+      [] _ then
+         skip
+      end end
+   end
+   Return='unification'([
+      cyclic( % unification should work with cyclic structures
+         proc{$}
+            A = 1|2|A
+            B = 1|2|1|2|B
+            C = '|'(1 '|'(2 C))
+            
+            D = rec(D d)
+            E = rec(E e)
+
+            M = rec(a rec(b rec(m)))
+            N = rec(a rec(b rec(n)))
+            
+            F = rec(G F)
+            G = rec(F G)
+         in
+            A = B
+            A = C
+            B = C
+            F = G
+
+            (A==B) = true
+            (A==C) = true
+            (B==C) = true
+            (F==G) = true
+
+            {MustFail 'D=E' proc{$} D=E end}
+            (D==E) = false
+
+            {MustFail 'M=N' proc{$} M=N end}
+            (M==N) = false
+         end
+         keys: [cyclic equality unification cons]
+      )
+      pattern_matching( % Cyclic patterns are only possible using variables which
+         % are handled through equality, so it should not cause problems.
+         proc{$}
+            A = rec(A 1)
+            B = rec(B 2)
+
+            C = 1|C
+            D = 1|D
+            X = 1|nil
+         in
+            case rec(B 1) of !A then
+               raise '  B not equal to A' end
+            else
+               case rec(B 2) of !B then
+                  skip
+               else
+                  raise '  recursive pattern fails' end
+               end
+            end
+            
+            case A of rec(!A 1) then
+               case B of rec(!B 2) then
+                  skip
+               else
+                  raise '  !B in pattern fails' end
+               end
+            else
+               raise '  !A in pattern fails' end
+            end
+
+            case C of 1|!C then
+               skip
+            else
+               raise '  !C in cons pattern fails' end
+            end
+         end
+         keys: [pattern_matching cyclic]
+      )
+      respecialization( % unification site should guard equality call correctly
+         % Equality only if A and B are not variables and A and B are not both records
+         proc{$}
+            proc{Unify A B}
+               A = B
+            end
+            A
+         in
+            {Unify 2 2}
+            % Erroneous case throws a Java exception which will still be propagated
+            {MustFail 'equality specialization' proc{$} {Unify rec(A) 2} end}
+         end
+         keys: [truffle unification]
+      )
+   ])
+end

--- a/platform-test/base/unification.oz
+++ b/platform-test/base/unification.oz
@@ -4,17 +4,14 @@ import
 export
    Return
 define
-   ShouldHaveFailed = 'should have failed'
    proc{MustFail X P}
       skip
       try
          {P}
-         raise ShouldHaveFailed end
-      catch S then case S of !ShouldHaveFailed then
-         raise '  '(X ShouldHaveFailed) end
-      [] _ then
+         raise {VirtualString.toAtom '  '#X#' should have failed'} end
+      catch failure(...) then
          skip
-      end end
+      end
    end
    Return='unification'([
       cyclic( % unification should work with cyclic structures
@@ -97,7 +94,6 @@ define
             A
          in
             {Unify 2 2}
-            % Erroneous case throws a Java exception which will still be propagated
             {MustFail 'equality specialization' proc{$} {Unify rec(A) 2} end}
          end
          keys: [truffle unification]

--- a/vm/src/org/mozartoz/truffle/Main.java
+++ b/vm/src/org/mozartoz/truffle/Main.java
@@ -24,6 +24,7 @@ public class Main {
 			BASE_TESTS + "byneed.oz",
 			BASE_TESTS + "future.oz",
 			BASE_TESTS + "tailrec.oz",
+			BASE_TESTS + "unification.oz",
 	};
 
 	public static void main(String[] args) {

--- a/vm/src/org/mozartoz/truffle/Options.java
+++ b/vm/src/org/mozartoz/truffle/Options.java
@@ -26,6 +26,8 @@ public abstract class Options {
 
 	public static final boolean OPTIMIZE_METHODS = bool("oz.methods.cache", true);
 
+	public static final int CYCLE_THRESHOLD = integer("oz.thresholds.cycles", 20);
+
 	// Truffle options
 	public static final int TruffleInvalidationReprofileCount = integer("graal.TruffleInvalidationReprofileCount", 3);
 	public static final int TruffleOSRCompilationThreshold = integer("graal.TruffleOSRCompilationThreshold", 100_000);

--- a/vm/src/org/mozartoz/truffle/nodes/local/BindNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/BindNode.java
@@ -18,7 +18,7 @@ public abstract class BindNode extends OzNode {
 		return BindNodeGen.create(null, null);
 	}
 
-	@Child UnifyNode unifyNode;
+	@Child GenericUnifyNode unifyNode;
 	@Child BindVarValueNode bindVarValueNode;
 
 	@CreateCast("left")
@@ -92,7 +92,7 @@ public abstract class BindNode extends OzNode {
 	private Object unify(Object a, Object b) {
 		if (unifyNode == null) {
 			CompilerDirectives.transferToInterpreter();
-			unifyNode = insert(UnifyNode.create());
+			unifyNode = insert(GenericUnifyNode.create());
 		}
 		return unifyNode.executeUnify(a, b);
 	}

--- a/vm/src/org/mozartoz/truffle/nodes/local/DFSEqualNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/DFSEqualNode.java
@@ -1,0 +1,189 @@
+package org.mozartoz.truffle.nodes.local;
+
+import java.math.BigInteger;
+
+import org.mozartoz.truffle.nodes.DerefIfBoundNode;
+import org.mozartoz.truffle.nodes.DerefIfBoundNodeGen;
+import org.mozartoz.truffle.nodes.OzNode;
+import org.mozartoz.truffle.runtime.OzChunk;
+import org.mozartoz.truffle.runtime.OzCons;
+import org.mozartoz.truffle.runtime.OzException;
+import org.mozartoz.truffle.runtime.OzName;
+import org.mozartoz.truffle.runtime.OzObject;
+import org.mozartoz.truffle.runtime.OzProc;
+import org.mozartoz.truffle.runtime.OzThread;
+import org.mozartoz.truffle.runtime.OzUniqueName;
+import org.mozartoz.truffle.runtime.OzVar;
+import org.mozartoz.truffle.runtime.Unit;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.object.Property;
+
+@NodeChildren({ @NodeChild("left"), @NodeChild("right") })
+public abstract class DFSEqualNode extends OzNode {
+
+	public static DFSEqualNode create() {
+		return DFSEqualNodeGen.create(null, null);
+	}
+
+	@Child DerefIfBoundNode derefIfBoundNode = DerefIfBoundNodeGen.create();
+
+	public abstract boolean executeEqual(Object a, Object b);
+
+	@TruffleBoundary
+	protected boolean equalRec(Object a, Object b) {
+		return executeEqual(deref(a), deref(b));
+	}
+
+	@Specialization(guards = { "!isBound(a)", "!isBound(b)" })
+	protected boolean equal(OzVar a, OzVar b) {
+		while (!a.isLinkedTo(b) && !a.isBound() && !b.isBound()) {
+			a.makeNeeded();
+			b.makeNeeded();
+			OzThread.getCurrent().yield(this);
+		}
+		if (a.isLinkedTo(b)) {
+			return true;
+		} else {
+			throw new OzException(this, "unimplemented");
+		}
+	}
+
+	@Specialization(guards = { "!isBound(a)", "!isVariable(b)" })
+	protected Object equal(OzVar a, Object b) {
+		return equalRec(a.waitValue(this), b);
+	}
+
+	@Specialization(guards = { "!isVariable(a)", "!isBound(b)" })
+	protected Object equal(Object a, OzVar b) {
+		return equalRec(a, b.waitValue(this));
+	}
+
+	@Specialization
+	protected boolean equal(boolean a, boolean b) {
+		return a == b;
+	}
+
+	@Specialization
+	protected boolean equal(long a, long b) {
+		return a == b;
+	}
+
+	@Specialization(guards = { "!isVariable(b)", "!isLong(b)", "!isBigInteger(b)" })
+	protected boolean equal(long a, Object b) {
+		return false;
+	}
+
+	@Specialization(guards = { "!isVariable(a)", "!isLong(a)", "!isBigInteger(a)" })
+	protected boolean equal(Object a, long b) {
+		return false;
+	}
+
+	@TruffleBoundary
+	@Specialization
+	protected boolean equal(BigInteger a, BigInteger b) {
+		return a.equals(b);
+	}
+
+	@Specialization
+	protected boolean equal(double a, double b) {
+		return a == b;
+	}
+
+	@Specialization
+	protected boolean equal(Unit a, Unit b) {
+		return true;
+	}
+
+	@Specialization
+	protected boolean equal(String a, String b) {
+		return a == b;
+	}
+
+	@Specialization(guards = { "!isVariable(b)", "!isAtom(b)" })
+	protected boolean equal(String a, Object b) {
+		return false;
+	}
+
+	@Specialization(guards = { "!isVariable(a)", "!isAtom(a)" })
+	protected boolean equal(Object a, String b) {
+		return false;
+	}
+
+	@Specialization
+	protected boolean equal(OzName a, OzName b) {
+		return a == b;
+	}
+
+	@Specialization
+	protected boolean equal(OzUniqueName a, OzUniqueName b) {
+		return a == b;
+	}
+
+	@Specialization
+	protected boolean equal(OzThread a, OzThread b) {
+		return a == b;
+	}
+
+	@Specialization
+	protected boolean equal(OzChunk a, OzChunk b) {
+		return a == b;
+	}
+
+	@Specialization
+	protected boolean equal(OzObject a, OzObject b) {
+		return a == b;
+	}
+
+	@Specialization
+	protected boolean equal(OzProc a, OzProc b) {
+		return a.equals(b);
+	}
+
+	@TruffleBoundary
+	@Specialization
+	protected boolean equal(OzCons a, OzCons b) {
+		return equalRec(a.getHead(), b.getHead()) && equalRec(a.getTail(), b.getTail());
+	}
+
+	@TruffleBoundary
+	@Specialization
+	protected boolean equal(DynamicObject a, DynamicObject b) {
+		if (a.getShape() != b.getShape()) {
+			return false;
+		}
+		for (Property property : a.getShape().getProperties()) {
+			Object aValue = property.get(a, a.getShape());
+			Object bValue = property.get(b, b.getShape());
+			if (!equalRec(aValue, bValue)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Specialization(guards = { "!isVariable(b)", "!isCons(b)", "!isRecord(b)" })
+	protected boolean equal(OzCons a, Object b) {
+		return false;
+	}
+
+	@Specialization(guards = { "!isVariable(b)", "!isRecord(b)" })
+	protected boolean equal(DynamicObject record, Object b) {
+		return false;
+	}
+
+	@Specialization(guards = { "a.getClass() != b.getClass()",
+			"!isVariable(a)", "!isLong(a)", "!isBigInteger(a)", "!isAtom(a)", "!isCons(a)", "!isRecord(a)" })
+	protected boolean equalRest(Object a, Object b) {
+		return false;
+	}
+
+	protected Object deref(Object value) {
+		return derefIfBoundNode.executeDerefIfBound(value);
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/nodes/local/DFSUnifyNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/DFSUnifyNode.java
@@ -109,7 +109,7 @@ public abstract class DFSUnifyNode extends OzNode {
 	}
 
 	public void failUnification(Object a, Object b) {
-		throw new OzException(this, "Failed unification: " + a + " != " + b);
+		throw new OzException(this, OzException.newFailure());
 	}
 
 }

--- a/vm/src/org/mozartoz/truffle/nodes/local/GenericEqualNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/GenericEqualNode.java
@@ -1,0 +1,112 @@
+package org.mozartoz.truffle.nodes.local;
+
+import java.util.HashSet;
+
+import org.mozartoz.truffle.Options;
+import org.mozartoz.truffle.nodes.OzNode;
+import org.mozartoz.truffle.nodes.local.GenericEqualNodeGen.CycleDetectingEqualNodeGen;
+import org.mozartoz.truffle.nodes.local.GenericEqualNodeGen.DummyEqualNodeGen;
+import org.mozartoz.truffle.runtime.DeoptimizingException;
+import org.mozartoz.truffle.runtime.IdentityPair;
+import org.mozartoz.truffle.runtime.Variable;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.coro.CoroutineLocal;
+
+@NodeChildren({ @NodeChild("left"), @NodeChild("right") })
+public abstract class GenericEqualNode extends OzNode {
+
+	public static GenericEqualNode create() {
+		return GenericEqualNodeGen.create(null, null);
+	}
+
+	public abstract boolean executeEqual(Object a, Object b);
+
+	@Specialization(rewriteOn = DeoptimizingException.class)
+	protected boolean dummyEqual(Object a, Object b,
+			@Cached("create()") DummyEqualNode equalNode) {
+		return equalNode.resetAndEqual(a, b);
+	}
+
+	@Specialization(contains = "dummyEqual")
+	protected boolean cycleDetectingEqual(Object a, Object b,
+			@Cached("create()") CycleDetectingEqualNode equalNode) {
+		return equalNode.resetAndEqual(a, b);
+	}
+
+	@NodeChildren({ @NodeChild("left"), @NodeChild("right") })
+	public static abstract class DummyEqualNode extends DFSEqualNode {
+		CoroutineLocal<MutableInt> count = new CoroutineLocal<GenericEqualNode.MutableInt>() {
+			protected MutableInt initialValue() {
+				return new MutableInt();
+			}
+		};
+		
+		public static DummyEqualNode create() {
+			return DummyEqualNodeGen.create(null, null);
+		}
+
+		public boolean resetAndEqual(Object a, Object b) {
+			MutableInt counter = count.get();
+			counter.reset();
+			return this.executeEqual(a, b);
+		}
+
+		@Override
+		@TruffleBoundary
+		protected boolean equalRec(Object a, Object b) {
+			MutableInt counter = count.get();
+			if (counter.inc() > Options.CYCLE_THRESHOLD) {
+				CompilerDirectives.transferToInterpreterAndInvalidate();
+				throw DeoptimizingException.INSTANCE;
+			}
+			return executeEqual(deref(a), deref(b));
+		}
+	}
+
+	@NodeChildren({ @NodeChild("left"), @NodeChild("right") })
+	public static abstract class CycleDetectingEqualNode extends DFSEqualNode {
+		CoroutineLocal<HashSet<IdentityPair>> encountered = new CoroutineLocal<>();
+
+		public static CycleDetectingEqualNode create() {
+			return CycleDetectingEqualNodeGen.create(null, null);
+		}
+
+		public boolean resetAndEqual(Object a, Object b) {
+			encountered.set(new HashSet<>());
+			boolean result = this.executeEqual(a, b);
+			encountered.set(null);
+			return result;
+		}
+
+		@Override
+		@TruffleBoundary
+		protected boolean equalRec(Object a, Object b) {
+			if (a instanceof Variable || b instanceof Variable) {
+				IdentityPair pair = new IdentityPair(a, b);
+				if (!encountered.get().add(pair)) {
+					return true;
+				}
+			}
+			return executeEqual(deref(a), deref(b));
+		}
+	}
+
+	public static final class MutableInt {
+		public int value;
+
+		public int inc() {
+			return ++value;
+		}
+
+		public void reset() {
+			value = 0;
+		}
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/nodes/local/GenericUnifyNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/GenericUnifyNode.java
@@ -1,0 +1,94 @@
+package org.mozartoz.truffle.nodes.local;
+
+import java.util.HashSet;
+
+import org.mozartoz.truffle.Options;
+import org.mozartoz.truffle.nodes.OzNode;
+import org.mozartoz.truffle.nodes.local.GenericUnifyNodeGen.CycleDetectingUnifyNodeGen;
+import org.mozartoz.truffle.nodes.local.GenericUnifyNodeGen.DummyUnifyNodeGen;
+import org.mozartoz.truffle.runtime.DeoptimizingException;
+import org.mozartoz.truffle.runtime.IdentityPair;
+import org.mozartoz.truffle.runtime.Variable;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+
+@NodeChildren({ @NodeChild("left"), @NodeChild("right") })
+public abstract class GenericUnifyNode extends OzNode {
+	public abstract Object executeUnify(Object a, Object b);
+
+	public static GenericUnifyNode create() {
+		return GenericUnifyNodeGen.create(null, null);
+	}
+
+	@Specialization(rewriteOn = DeoptimizingException.class)
+	protected Object dummyUnify(Object a, Object b,
+			@Cached("create()") DummyUnifyNode unifyNode) {
+		return unifyNode.resetAndUnify(a, b);
+	}
+
+	@Specialization(contains = "dummyUnify")
+	protected Object cycleDetectingUnify(Object a, Object b,
+			@Cached("create()") CycleDetectingUnifyNode unifyNode) {
+		return unifyNode.resetAndUnify(a, b);
+	}
+
+	@NodeChildren({ @NodeChild("left"), @NodeChild("right") })
+	public static abstract class DummyUnifyNode extends DFSUnifyNode {
+		// No need to put it as CoroutineLocal, as unification cannot be interrupted.
+		private int count = 0;
+
+		public static DummyUnifyNode create() {
+			return DummyUnifyNodeGen.create(null, null);
+		}
+
+		public Object resetAndUnify(Object a, Object b) {
+			count = 0;
+			return this.executeUnify(a, b);
+		}
+
+		@Override
+		@TruffleBoundary
+		protected Object unify(Object a, Object b) {
+			if (++count > Options.CYCLE_THRESHOLD) {
+				CompilerDirectives.transferToInterpreterAndInvalidate();
+				throw DeoptimizingException.INSTANCE;
+			}
+			return executeUnify(deref(a), deref(b));
+		}
+	}
+
+	@NodeChildren({ @NodeChild("left"), @NodeChild("right") })
+	public static abstract class CycleDetectingUnifyNode extends DFSUnifyNode {
+		// No need to put it as CoroutineLocal, as unification cannot be interrupted.
+		private HashSet<IdentityPair> encountered = new HashSet<>();
+
+		public static CycleDetectingUnifyNode create() {
+			return CycleDetectingUnifyNodeGen.create(null, null);
+		}
+
+		public Object resetAndUnify(Object a, Object b) {
+			encountered = new HashSet<>();
+			Object result = this.executeUnify(a, b);
+			encountered = null;
+			return result;
+		}
+
+		@Override
+		@TruffleBoundary
+		protected Object unify(Object a, Object b) {
+			if (a instanceof Variable || b instanceof Variable) {
+				IdentityPair pair = new IdentityPair(a, b);
+				if (!encountered.add(pair)) {
+					return a;
+				}
+			}
+			return executeUnify(deref(a), deref(b));
+		}
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/nodes/pattern/PatternMatchEqualNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/pattern/PatternMatchEqualNode.java
@@ -3,7 +3,7 @@ package org.mozartoz.truffle.nodes.pattern;
 import org.mozartoz.truffle.nodes.DerefNode;
 import org.mozartoz.truffle.nodes.OzGuards;
 import org.mozartoz.truffle.nodes.OzNode;
-import org.mozartoz.truffle.nodes.builtins.ValueBuiltins.EqualNode;
+import org.mozartoz.truffle.nodes.local.DFSEqualNode;
 
 import com.oracle.truffle.api.dsl.CreateCast;
 import com.oracle.truffle.api.dsl.NodeChild;
@@ -14,7 +14,7 @@ public abstract class PatternMatchEqualNode extends OzNode {
 
 	private final Object constant;
 
-	@Child EqualNode equalNode = EqualNode.create();
+	@Child DFSEqualNode equalNode = DFSEqualNode.create();
 
 	@CreateCast("value")
 	protected OzNode derefValue(OzNode value) {

--- a/vm/src/org/mozartoz/truffle/runtime/Arity.java
+++ b/vm/src/org/mozartoz/truffle/runtime/Arity.java
@@ -77,7 +77,7 @@ public class Arity {
 	public boolean matchesOpen(DynamicObject object) {
 		Shape a = object.getShape();
 		Shape b = shape;
-		return a.isRelated(b) && a.getPropertyCount() >= b.getPropertyCount() && isAncestorShape(a, b);
+		return a.isRelated(b) && a.getPropertyCount() >= b.getPropertyCount() && isAncestorShape(a, b) && LABEL_LOCATION.get(object) == label;
 	}
 
 	private boolean isAncestorShape(Shape shape, Shape ancestor) {

--- a/vm/src/org/mozartoz/truffle/runtime/DeoptimizingException.java
+++ b/vm/src/org/mozartoz/truffle/runtime/DeoptimizingException.java
@@ -1,0 +1,20 @@
+package org.mozartoz.truffle.runtime;
+
+/**
+ * Stacktraceless exception for triggering deoptimization manually
+ */
+public final class DeoptimizingException extends RuntimeException {
+	private static final long serialVersionUID = -304210520191451179L;
+	public static final DeoptimizingException INSTANCE = new DeoptimizingException();
+
+	private DeoptimizingException() {
+		super(null, null);
+	}
+
+	@SuppressWarnings("sync-override")
+	@Override
+	public final Throwable fillInStackTrace() {
+		return null;
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/runtime/IdentityPair.java
+++ b/vm/src/org/mozartoz/truffle/runtime/IdentityPair.java
@@ -1,0 +1,42 @@
+package org.mozartoz.truffle.runtime;
+
+/**
+ * An identity pair class to be used in general unification and equality
+ * algorithms. Allows recognizing identical pairs of objects within collections.
+ */
+public class IdentityPair implements Comparable<IdentityPair> {
+	private final Object a, b;
+	private final int hashCode;
+
+	public IdentityPair(Object a, Object b) {
+		if (a.hashCode() < b.hashCode()) {
+			this.a = a;
+			this.b = b;
+		} else {
+			this.a = b;
+			this.b = a;
+		}
+		long hashCode64 = ((long) System.identityHashCode(this.a) << 32) | System.identityHashCode(this.b);
+		this.hashCode = (int) ((hashCode64 >> 16) ^ hashCode64); // TODO improve distribution?
+	}
+
+	@Override
+	public int hashCode() {
+		return hashCode;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof IdentityPair)) {
+			return false;
+		}
+		IdentityPair pair = (IdentityPair) obj;
+		return this.a == pair.a && this.b == pair.b;
+	}
+
+	@Override
+	public int compareTo(IdentityPair o) {
+		return hashCode - o.hashCode;
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/runtime/IdentityPair.java
+++ b/vm/src/org/mozartoz/truffle/runtime/IdentityPair.java
@@ -9,14 +9,18 @@ public class IdentityPair implements Comparable<IdentityPair> {
 	private final int hashCode;
 
 	public IdentityPair(Object a, Object b) {
-		if (a.hashCode() < b.hashCode()) {
+		int ha = System.identityHashCode(a);
+		int hb = System.identityHashCode(b);
+		long hashCode64;
+		if (ha < hb) {
 			this.a = a;
 			this.b = b;
+			hashCode64 = ((long) ha << 32) | hb;
 		} else {
 			this.a = b;
 			this.b = a;
+			hashCode64 = ((long) hb << 32) | ha;
 		}
-		long hashCode64 = ((long) System.identityHashCode(this.a) << 32) | System.identityHashCode(this.b);
 		this.hashCode = (int) ((hashCode64 >> 16) ^ hashCode64); // TODO improve distribution?
 	}
 

--- a/vm/src/org/mozartoz/truffle/runtime/Variable.java
+++ b/vm/src/org/mozartoz/truffle/runtime/Variable.java
@@ -38,12 +38,13 @@ public abstract class Variable {
 	public void link(Variable other) {
 		assert !isBound();
 		assert !other.isBound();
-		assert !isLinkedTo(other);
 
-		// Link both circular lists
-		Variable oldNext = this.next;
-		this.next = other.next;
-		other.next = oldNext;
+		if (!isLinkedTo(other)) {
+			// Link both circular lists
+			Variable oldNext = this.next;
+			this.next = other.next;
+			other.next = oldNext;
+		}
 	}
 
 	public boolean isLinkedTo(Variable other) {


### PR DESCRIPTION
…matching + bug fixes

The idea is basically to perform a DFS for unification and equality test (pattern matching using equality test on variables, which are the only way to achieve circular patterns). That was what was done but was not correct for circular data structures.

Now, once a certain number of tests have been performed (depth-wise + breadth-wise, counted by Dummy(Unify/Equal)Node), a deoptimization exception is raised to switch to a unification (CycleDetectingXNode) version maintaining a set of unified pairs in order to detect cycles and not unify them several times. The book states that only storing couples of variables is sufficient, but as dereference happens, some variables are not available in the record anymore. So cycle detection is ensured by storing all the pairs containing a variable.

Another version could make use of an explicit stack, in order to be able to unify deep lists, ... Probably some work for later I'll discuss in the dissertation.

I think the changes are near to the minimal required in order to pass the tests.