### PR TITLE
Rework captured environment and clear local variables early

### DIFF
--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/CommonStatExpr.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/CommonStatExpr.scala
@@ -1,6 +1,8 @@
 package org.mozartoz.bootcompiler
 package ast
 
+import org.mozartoz.bootcompiler.symtab.Symbol
+
 trait StatOrExpr extends Node
 
 trait LocalCommon extends StatOrExpr {
@@ -212,4 +214,17 @@ trait BindCommon extends StatOrExpr with InfixSyntax {
   protected val opSyntax = " = "
   
   override def syntax(indent: String) = super.syntax(indent) + (if (onStack) "(stack)" else "")
+}
+
+trait ClearVarsCommon extends StatOrExpr {
+	protected val node: StatOrExpr
+  protected val before: Seq[Symbol]
+  protected val after: Seq[Symbol]
+  
+  override def syntax(indent: String) = {
+    val subIndent = indent + "   "
+	  "/"+before.mkString(",")+"/" + "\n"+
+	    subIndent+node.syntax(subIndent) + "\n" +
+	  indent + "\\"+after.mkString(",")+"\\"
+	}
 }

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Expressions.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Expressions.scala
@@ -369,10 +369,11 @@ case class RawVariable(name: String)(val pos: Pos) extends VariableOrRaw with Ra
 case class Variable(symbol: Symbol)(val pos: Pos) extends VarOrConst with VariableOrRaw with Phrase
     with RawDeclarationOrVar {
   var onStack = false
+  var clear = false
   def name = symbol.name
 
   def syntax(indent: String) =
-    symbol.fullName + (if (onStack) "(onstack)" else "")
+    symbol.fullName + (if (clear) "\\" else "") + (if (onStack) "(onstack)" else "")
 }
 
 /** Factory for Variable */
@@ -698,3 +699,6 @@ case class ClassExpression(name: String, parents: Seq[Expression],
     untilMethods + "\n\n" + indent + "end"
   }
 }
+
+case class ClearVarsExpression(node: Expression, before: Seq[Symbol],
+    after: Seq[Symbol])(val pos: Pos) extends Expression with ClearVarsCommon

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Statements.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Statements.scala
@@ -2,6 +2,7 @@ package org.mozartoz.bootcompiler
 package ast
 
 import Node.Pos
+import org.mozartoz.bootcompiler.symtab.Symbol
 
 /** Base class for ASTs that represent statements */
 sealed abstract class Statement extends StatOrExpr with RawDeclaration
@@ -252,3 +253,6 @@ case class DotAssignStatement(left: Expression, center: Expression,
 case class SkipStatement()(val pos: Pos) extends Statement with Phrase {
   def syntax(indent: String) = "skip"
 }
+
+case class ClearVarsStatement(node: Statement, before: Seq[Symbol],
+    after: Seq[Symbol])(val pos: Pos) extends Statement with ClearVarsCommon

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Statements.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Statements.scala
@@ -3,6 +3,7 @@ package ast
 
 import Node.Pos
 import org.mozartoz.bootcompiler.symtab.Symbol
+import org.mozartoz.bootcompiler.util.WrapperUtil
 
 /** Base class for ASTs that represent statements */
 sealed abstract class Statement extends StatOrExpr with RawDeclaration
@@ -116,11 +117,13 @@ case class NoElseStatement()(val pos: Pos) extends Statement with NoElseCommon {
  *  end
  *  }}}
  */
-case class ForStatement(from: Expression, to: Expression, proc: ProcExpression)(val pos: Pos) extends Statement {
+case class ForStatement(from: Expression, to: Expression, proc: Expression)(val pos: Pos) extends Statement {
+  def procExpr = WrapperUtil.getInnerExpr(proc).asInstanceOf[ProcExpression]
+  
   def syntax(indent: String) = {
-    val variable = proc.args(0)
+    val variable = procExpr.args(0)
     val decl = "for " + variable.syntax(indent) + " in " + from.syntax(indent) + ".." + to.syntax(indent) + " do"
-    decl + "\n" + proc.body.syntax(indent + "   ") + "\n" + indent + "end"
+    decl + "\n" + procExpr.body.syntax(indent + "   ") + "\n" + indent + "end"
   }
 }
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/OnStackMarking.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/OnStackMarking.scala
@@ -30,7 +30,7 @@ sealed class VarState(val onStack: Boolean, val locked: Boolean) {
   }
 }
 object Declared      extends VarState(true, false)
-object Captured      extends VarState(false, false)
+object Captured      extends VarState(false, true) // TODO false false if frame hierarchy, false true if extraction
 object BoundFirst    extends VarState(true, true)
 object ToInstantiate extends VarState(false, true)
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Transformer.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Transformer.scala
@@ -112,6 +112,9 @@ abstract class Transformer extends (Program => Unit) {
 
     case SkipStatement() =>
       treeCopy.SkipStatement(statement)
+      
+    case ClearVarsStatement(stat, before, after) =>
+      treeCopy.ClearVarsStatement(statement, transformStat(stat), before, after)
   }
 
   /** Transforms an expression */
@@ -190,6 +193,9 @@ abstract class Transformer extends (Program => Unit) {
           require, prepare map transformDefine,
           imports, define map transformDefine,
           exports)
+      
+    case ClearVarsExpression(expr, before, after) =>
+      treeCopy.ClearVarsExpression(expression, transformExpr(expr), before, after)
 
     // Operations
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Transformer.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Transformer.scala
@@ -72,7 +72,7 @@ abstract class Transformer extends (Program => Unit) {
 
     case ForStatement(from, to, proc) =>
       treeCopy.ForStatement(statement, transformExpr(from), transformExpr(to),
-        transformExpr(proc).asInstanceOf[ProcExpression])
+        transformExpr(proc))
 
     case ThreadStatement(body) =>
       treeCopy.ThreadStatement(statement, transformStat(body))

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TreeCopier.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TreeCopier.scala
@@ -85,6 +85,9 @@ class TreeCopier {
 
   def SkipStatement(tree: Node) =
     new SkipStatement()(tree)
+    
+  def ClearVarsStatement(tree: Node, node: Statement, before: Seq[Symbol], after: Seq[Symbol])=
+    new ClearVarsStatement(node, before, after)(tree)
 
   // Expressions
 
@@ -150,6 +153,9 @@ class TreeCopier {
   def DotAssignExpression(tree: Node, left: Expression, center: Expression,
       right: Expression) =
     new DotAssignExpression(left, center, right)(tree)
+    
+  def ClearVarsExpression(tree: Node, node: Expression, before: Seq[Symbol], after: Seq[Symbol]) =
+    new ClearVarsExpression(node, before, after)(tree)
 
   // Functors
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TreeCopier.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TreeCopier.scala
@@ -46,7 +46,7 @@ class TreeCopier {
   def NoElseStatement(tree: Node) =
     new NoElseStatement()(tree)
 
-  def ForStatement(tree: Node, from: Expression, to: Expression, proc: ProcExpression) =
+  def ForStatement(tree: Node, from: Expression, to: Expression, proc: Expression) =
     new ForStatement(from, to, proc)(tree)
 
   def ThreadStatement(tree: Node, statement: Statement) =

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/VariableClearing.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/VariableClearing.scala
@@ -1,0 +1,292 @@
+package org.mozartoz.bootcompiler.transform
+
+import org.mozartoz.bootcompiler.ast.TreeDSL
+import org.mozartoz.bootcompiler.ast.ProcExpression
+import org.mozartoz.bootcompiler.ast.Expression
+import scala.collection.mutable.HashMap
+import org.mozartoz.bootcompiler.ast.Node
+import org.mozartoz.bootcompiler.ast.LocalStatement
+import org.mozartoz.bootcompiler.ast.Statement
+import org.mozartoz.bootcompiler.symtab.Symbol
+import org.mozartoz.bootcompiler.ast.Variable
+import org.mozartoz.bootcompiler.ast.IfStatement
+import scala.collection.mutable.HashSet
+import scala.collection.mutable.Buffer
+import org.mozartoz.bootcompiler.ast.StatOrExpr
+import org.mozartoz.bootcompiler.symtab.Symbol
+import org.mozartoz.bootcompiler.ast.IfExpression
+import java.util.IdentityHashMap
+import scala.collection.mutable.ArrayBuffer
+import org.mozartoz.bootcompiler.ast.MatchExpression
+import org.mozartoz.bootcompiler.ast.MatchStatement
+import org.mozartoz.bootcompiler.ast.LocalExpression
+import org.mozartoz.bootcompiler.ast.NoElseExpression
+import org.mozartoz.bootcompiler.ast.NoElseStatement
+
+
+/**
+ * Designates a node a variable should be cleared at.
+ */
+case class ClearSite(node: StatOrExpr, before: Boolean)
+/**
+ * The complementary, a variable a node should clear. These two could be merged, but the separated
+ * approach allows to express sites without decided symbols
+ */
+case class Clear(sym: Symbol, before: Boolean)
+
+/**
+ * Variables cleared in branches. Must also designate which node should clear variables cleared
+ * from other branches.
+ */
+case class BranchClearsMap(clearsMap: HashMap[Symbol, Seq[ClearSite]], default: ClearSite)
+
+object VariableClearing extends Transformer with ReverseWalker {
+  type ClearsMap = HashMap[Symbol, Seq[ClearSite]]
+  
+  // Map of variables and the nodes eliminating them
+  var clearsMap: ClearsMap = new HashMap();
+  
+  def undecided(): ClearsMap = {
+    val ret = HashMap[Symbol, Seq[ClearSite]]()
+    for ((k, v) <- clearsMap if v == null) {
+      ret.put(k, null)
+    }
+    ret
+  }
+  
+  def withClearsMap[A](clearsMap: ClearsMap)(f: => A): A = {
+    val oldClearsMap = this.clearsMap
+    this.clearsMap = clearsMap
+    try {
+      return f
+    } finally {
+      this.clearsMap = oldClearsMap
+    }
+  }
+  
+  def merge(branches: BranchClearsMap*) = {
+    val localClearsMap = new HashMap[Symbol, Buffer[ClearSite]]()
+    val localTouched = new HashSet[Symbol]()
+    
+    val branchClearsMaps = branches.map(_.clearsMap) // Actual clears from branches
+    val branchDefault = branches.map(_.default) // ClearVar for missing variable clears
+    
+    // ClearVars from branches must be propagated
+    for ((branchClearsMap, i) <- branchClearsMaps.zipWithIndex) {
+      for ((sym, nodes) <- branchClearsMap) {
+        if (nodes != null) {
+          localTouched.add(sym)
+        	val buffer = localClearsMap.getOrElseUpdate(sym, ArrayBuffer[ClearSite]())
+    			buffer ++= nodes
+        }
+      }
+    }
+    
+    // Variables that are cleared by a branch but not by another should be in the other ones as well
+    // But only if they have been declared outside the branch!
+    for((branchClearsMap, i) <- branchClearsMaps.zipWithIndex) {
+      for (sym <- localTouched if branchClearsMap.get(sym) == Some(null)) {
+        	val buffer = localClearsMap.getOrElseUpdate(sym, ArrayBuffer[ClearSite]())
+      	  buffer += branchDefault(i)
+      }
+    }
+    
+    // Changes are then to be made global
+    for ((sym, clears) <- localClearsMap) {
+      clearsMap.put(sym, clears)
+    }
+  }
+  
+  override def walkStat(statement: Statement) = statement match {
+    case LocalStatement(decls, stat) =>
+      decls.foreach { decl =>
+        clearsMap.put(decl.symbol, null)
+      }
+      walkStat(stat)
+      
+    case IfStatement(condition, trueStat, falseStat) =>
+      merge(withClearsMap(undecided) {
+        walkStat(trueStat)
+        BranchClearsMap(this.clearsMap, ClearSite(trueStat, true))
+      }, withClearsMap(undecided) {
+    	  walkStat(falseStat)
+        BranchClearsMap(this.clearsMap, ClearSite(falseStat, true))
+      })
+      walkExpr(condition)
+      
+    case MatchStatement(value, clauses, elseStatement) =>
+      def clearVal(stat: Statement) = {
+        val sym = value.asInstanceOf[Variable].symbol
+        if (this.clearsMap.get(sym) == Some(null))
+          this.clearsMap.put(sym, Seq(ClearSite(stat, false)))
+      }
+      
+      merge((clauses.map { clause =>
+        withClearsMap(undecided) {
+        	walkStat(clause.body)
+        	clause.guard.foreach(walkExpr(_))
+        	walkExpr(clause.pattern)
+        	clearVal(clause.body)
+        	BranchClearsMap(this.clearsMap, ClearSite(clause.body, true))
+        }
+      } :+ withClearsMap(undecided) {
+        walkStat(elseStatement)
+        clearVal(elseStatement)
+        BranchClearsMap(this.clearsMap, ClearSite(elseStatement, true))
+      }): _*)
+      
+    case _ => super.walkStat(statement)
+  }
+  
+  override def walkExpr(expression: Expression) = expression match {
+    case v @ Variable(sym) =>
+      if (clearsMap.get(sym) == Some(null)) {
+        clearsMap.put(sym, Seq(ClearSite(v, before=false)))
+      }
+      
+    case LocalExpression(decls, expr) =>
+      decls.foreach { decl =>
+        clearsMap.put(decl.symbol, null)
+      }
+      walkExpr(expr)
+      
+    case ProcExpression(name, args, body, flags) =>
+      val walker = new CaptureWalker(this.clearsMap)
+      walker.walkStat(body)
+      val captured = walker.captured
+      for (sym <- walker.captured) {
+        clearsMap.put(sym, Seq(ClearSite(expression, before=false)))
+      }
+      
+    case IfExpression(condition, trueExpr, falseExpr) =>
+      merge(withClearsMap(undecided) {
+        walkExpr(trueExpr)
+        BranchClearsMap(this.clearsMap, ClearSite(trueExpr, true))
+      }, withClearsMap(undecided) {
+    	  walkExpr(falseExpr)
+        BranchClearsMap(this.clearsMap, ClearSite(falseExpr, true))
+      })
+      walkExpr(condition)
+      
+    case MatchExpression(value, clauses, elseExpression) =>
+      def clearVal(expr: Expression) = {
+        val sym = value.asInstanceOf[Variable].symbol
+        if (this.clearsMap.get(sym) == Some(null))
+          this.clearsMap.put(sym, Seq(ClearSite(expr, false)))
+      }
+      
+      merge((clauses.map { clause =>
+        withClearsMap(undecided) {
+        	walkExpr(clause.body)
+        	clause.guard.foreach(walkExpr(_))
+        	walkExpr(clause.pattern)
+        	clearVal(clause.body)
+        	BranchClearsMap(this.clearsMap, ClearSite(clause.body, true))
+        }
+      } :+ withClearsMap(undecided) {
+        walkExpr(elseExpression)
+        clearVal(elseExpression)
+        BranchClearsMap(this.clearsMap, ClearSite(elseExpression, true))
+      }): _*)
+      
+    
+    case _ => super.walkExpr(expression)
+  }
+  
+  var nodeReplacements: IdentityHashMap[StatOrExpr, Buffer[Clear]] = new IdentityHashMap()
+  def withNodeReplacement[A](nodeReplacements: IdentityHashMap[StatOrExpr, Buffer[Clear]])(f: => A): A = {
+    val oldNodeReplacements = this.nodeReplacements
+    this.nodeReplacements = nodeReplacements
+    try {
+      return f
+    } finally {
+      this.nodeReplacements = oldNodeReplacements
+    }
+  }
+  
+  def clearsMap2replacements(clearsMap: ClearsMap): IdentityHashMap[StatOrExpr, Buffer[Clear]] = {
+    val replacements = new IdentityHashMap[StatOrExpr, Buffer[Clear]]()
+    for ((sym, clears) <- clearsMap if clears != null) { // TODO WHAT IF UNENCOUNTERED?
+      for (ClearSite(node, before) <- clears) {
+        var buffer = replacements.get(node)
+        if (buffer == null) {
+          buffer = ArrayBuffer[Clear]()
+          replacements.put(node, buffer)
+        }
+        buffer += Clear(sym, before)
+      }
+    }
+    
+    replacements
+  }
+  
+  def replaceStat(statement: Statement): Statement = {
+    val replacements = nodeReplacements.get(statement)
+    if (replacements != null) {
+      treeCopy.ClearVarsStatement(statement, super.transformStat(statement),
+          replacements.filter(_.before).map(_.sym),
+          replacements.filter(!_.before).map(_.sym))
+    } else {
+  	  super.transformStat(statement)
+    }
+  }
+  
+  def replaceExpr(expression: Expression): Expression = {
+    val replacements = nodeReplacements.get(expression)
+      if (replacements != null) {
+        treeCopy.ClearVarsExpression(expression, super.transformExpr(expression),
+          replacements.filter(_.before).map(_.sym),
+          replacements.filter(!_.before).map(_.sym))
+      } else {
+    	  super.transformExpr(expression)
+      }
+  }
+  
+  override def transformExpr(expression: Expression) = expression match {
+    case proc @ ProcExpression(name, args, body, flags) =>
+      val clearsMap = withClearsMap(new HashMap()) {
+        args.foreach (_ match { case Variable(sym) => this.clearsMap.put(sym, null) })
+    	  walkStat(body)
+    	  this.clearsMap
+      }
+      withNodeReplacement(clearsMap2replacements(clearsMap)) {
+    	  treeCopy.ProcExpression(expression, name, args, replaceStat(body), flags)
+      }
+      
+    case v @ Variable(sym) => // Some nodes expect a variable as child. Do not create unnecessary resetters
+      val repl = nodeReplacements.get(v)
+      if (repl != null) {
+        val idx = repl.indexWhere { clear => clear.sym == sym }
+        if (idx >= 0) {
+          v.clear = true
+          if (repl.length == 1) {
+            nodeReplacements.put(v, null)
+          } else {
+            repl.remove(idx)
+          }
+        }
+      }
+      replaceExpr(v)
+      
+    case NoElseExpression() => expression
+    case _ => replaceExpr(expression)
+  }
+  
+  override def transformStat(statement: Statement) = statement match {
+    case NoElseStatement() => statement
+    case _ => replaceStat(statement)
+  }
+}
+
+class CaptureWalker(val map: HashMap[Symbol, Seq[ClearSite]]) extends Walker {
+  val captured = new HashSet[Symbol]()
+  
+  override def walkExpr(expression: Expression) = expression match {
+    case Variable(sym) =>
+      if (map.get(sym) == Some(null)) {
+    	  captured.add(sym)
+      }
+      
+    case _ => super.walkExpr(expression)
+  }
+}

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/VariableDeduplication.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/VariableDeduplication.scala
@@ -1,0 +1,12 @@
+package org.mozartoz.bootcompiler.transform
+
+import org.mozartoz.bootcompiler.ast._
+
+object VariableDeduplication extends Transformer with TreeDSL {
+  override def transformExpr(expression: Expression) = expression match {
+    case v @ Variable(sym) =>
+      treeCopy.Variable(v, sym)
+      
+    case _ => super.transformExpr(expression)
+  }
+}

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/util/WrapperUtil.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/util/WrapperUtil.scala
@@ -1,0 +1,19 @@
+package org.mozartoz.bootcompiler.util
+
+import org.mozartoz.bootcompiler.ast._
+
+object WrapperUtil {
+  def getInnerExpr(expression: Expression): Expression = expression match {
+    case ClearVarsExpression(expr, _, _) =>
+      expr
+    
+    case _ => expression
+  }
+  
+  def getInnerStat(statement: Statement): Statement = statement match {
+    case ClearVarsStatement(stat, _, _) =>
+      stat
+    
+    case _ => statement
+  }
+}

--- a/lib/main/init/Init.oz
+++ b/lib/main/init/Init.oz
@@ -359,6 +359,7 @@ define
 
       %% Link or apply root functor (i.e. application)
       proc {Main}
+         {Boot.registerBase Base}
          if {Not {PropertyTestGet 'oz.dotoz' _}} then {OnLoad} end
          AppFunctor = {GetOrFalse 'application.functor'}
       in

--- a/vm/src/org/mozartoz/truffle/Options.java
+++ b/vm/src/org/mozartoz/truffle/Options.java
@@ -19,6 +19,8 @@ public abstract class Options {
 
 	public static final boolean FREE_LINKS = bool("oz.free.links", true);
 	public static final boolean DIRECT_VARS = bool("oz.vars.direct", true);
+	public static final boolean FRAME_FILTERING = bool("oz.vars.filtering", true);
+	public static final boolean CACHE_READ = bool("oz.reads.cache", true);
 	public static final boolean PRINT_NLINKS = bool("oz.print.nlinks", false);
 	public static final boolean PRINT_NVARS = bool("oz.print.nvars", false);
 

--- a/vm/src/org/mozartoz/truffle/Options.java
+++ b/vm/src/org/mozartoz/truffle/Options.java
@@ -18,6 +18,7 @@ public abstract class Options {
 	public static final boolean STACKTRACE_ON_INTERRUPT = bool("oz.stacktrace.on_interrupt", false);
 
 	public static final boolean FREE_LINKS = bool("oz.free.links", true);
+	public static final boolean FREE_SLOTS = bool("oz.free.slots", true);
 	public static final boolean DIRECT_VARS = bool("oz.vars.direct", true);
 	public static final boolean FRAME_FILTERING = bool("oz.vars.filtering", true);
 	public static final boolean CACHE_READ = bool("oz.reads.cache", true);

--- a/vm/src/org/mozartoz/truffle/nodes/builtins/BootBuiltins.java
+++ b/vm/src/org/mozartoz/truffle/nodes/builtins/BootBuiltins.java
@@ -4,6 +4,7 @@ import static org.mozartoz.truffle.nodes.builtins.Builtin.ALL;
 
 import org.mozartoz.truffle.nodes.OzNode;
 import org.mozartoz.truffle.nodes.builtins.VirtualStringBuiltinsFactory.ToAtomNodeFactory;
+import org.mozartoz.truffle.translator.Loader;
 
 import com.oracle.truffle.api.dsl.CreateCast;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
@@ -38,6 +39,19 @@ public abstract class BootBuiltins {
 		@Specialization
 		Object getNative(Object name) {
 			return unimplemented();
+		}
+
+	}
+
+	@Builtin(proc = true, deref = ALL)
+	@GenerateNodeFactory
+	@NodeChild("base")
+	public static abstract class RegisterBaseNode extends OzNode {
+
+		@Specialization
+		Object registerBase(DynamicObject base) {
+			Loader.getInstance().registerBase(base);
+			return unit;
 		}
 
 	}

--- a/vm/src/org/mozartoz/truffle/nodes/control/ForNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/control/ForNode.java
@@ -33,6 +33,7 @@ public class ForNode extends OzNode {
 	public Object execute(VirtualFrame frame) {
 		long from = (long) fromDerefNode.executeDeref(fromNode.execute(frame));
 		long to = (long) toDerefNode.executeDeref(toNode.execute(frame));
+		OzProc proc = (OzProc) procNode.execute(frame);
 
 		int count = 0;
 		if (CompilerDirectives.inInterpreter()) {
@@ -42,7 +43,6 @@ public class ForNode extends OzNode {
 		try {
 			loopProfile.profileCounted(count);
 			for (long i = from; loopProfile.inject(i <= to); i++) {
-				OzProc proc = (OzProc) procNode.execute(frame);
 				callNode.executeCall(frame, proc, new Object[] { i });
 			}
 		} finally {

--- a/vm/src/org/mozartoz/truffle/nodes/literal/ProcDeclarationAndExtractionNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/literal/ProcDeclarationAndExtractionNode.java
@@ -2,7 +2,8 @@ package org.mozartoz.truffle.nodes.literal;
 
 import org.mozartoz.truffle.nodes.OzNode;
 import org.mozartoz.truffle.nodes.OzRootNode;
-import org.mozartoz.truffle.nodes.local.WriteFrameToFrameNode;
+import org.mozartoz.truffle.nodes.local.CopyVariableToFrameNode;
+import org.mozartoz.truffle.runtime.ArrayUtils;
 import org.mozartoz.truffle.runtime.OzProc;
 
 import com.oracle.truffle.api.RootCallTarget;
@@ -15,11 +16,11 @@ import com.oracle.truffle.api.nodes.ExplodeLoop;
 public class ProcDeclarationAndExtractionNode extends OzNode {
 
 	private final RootCallTarget callTarget;
-	private FrameDescriptor capturedDescriptor;
-	@Children final WriteFrameToFrameNode[] captureNodes;
+	private final FrameDescriptor capturedDescriptor;
+	@Children final CopyVariableToFrameNode[] captureNodes;
 	private final int arity;
 
-	public ProcDeclarationAndExtractionNode(RootCallTarget callTarget, FrameDescriptor capturedDescriptor, WriteFrameToFrameNode[] captureNodes) {
+	public ProcDeclarationAndExtractionNode(RootCallTarget callTarget, FrameDescriptor capturedDescriptor, CopyVariableToFrameNode[] captureNodes) {
 		this.callTarget = callTarget;
 		this.capturedDescriptor = capturedDescriptor;
 		this.captureNodes = captureNodes;
@@ -29,7 +30,7 @@ public class ProcDeclarationAndExtractionNode extends OzNode {
 	@Override
 	@ExplodeLoop
 	public Object execute(VirtualFrame frame) {
-		MaterializedFrame capture = Truffle.getRuntime().createMaterializedFrame(new Object[0], capturedDescriptor);
+		MaterializedFrame capture = Truffle.getRuntime().createMaterializedFrame(ArrayUtils.EMPTY, capturedDescriptor);
 		for (int i = 0; i < captureNodes.length; i++) {
 			captureNodes[i].executeWrite(frame, capture);
 		}

--- a/vm/src/org/mozartoz/truffle/nodes/literal/ProcDeclarationAndExtractionNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/literal/ProcDeclarationAndExtractionNode.java
@@ -1,0 +1,39 @@
+package org.mozartoz.truffle.nodes.literal;
+
+import org.mozartoz.truffle.nodes.OzNode;
+import org.mozartoz.truffle.nodes.OzRootNode;
+import org.mozartoz.truffle.nodes.local.WriteFrameToFrameNode;
+import org.mozartoz.truffle.runtime.OzProc;
+
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+
+public class ProcDeclarationAndExtractionNode extends OzNode {
+
+	private final RootCallTarget callTarget;
+	private FrameDescriptor capturedDescriptor;
+	@Children final WriteFrameToFrameNode[] captureNodes;
+	private final int arity;
+
+	public ProcDeclarationAndExtractionNode(RootCallTarget callTarget, FrameDescriptor capturedDescriptor, WriteFrameToFrameNode[] captureNodes) {
+		this.callTarget = callTarget;
+		this.capturedDescriptor = capturedDescriptor;
+		this.captureNodes = captureNodes;
+		this.arity = ((OzRootNode) callTarget.getRootNode()).getArity();
+	}
+
+	@Override
+	@ExplodeLoop
+	public Object execute(VirtualFrame frame) {
+		MaterializedFrame capture = Truffle.getRuntime().createMaterializedFrame(new Object[0], capturedDescriptor);
+		for (int i = 0; i < captureNodes.length; i++) {
+			captureNodes[i].executeWrite(frame, capture);
+		}
+		return new OzProc(callTarget, capture, arity);
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/nodes/literal/ProcDeclarationAndExtractionNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/literal/ProcDeclarationAndExtractionNode.java
@@ -30,7 +30,7 @@ public class ProcDeclarationAndExtractionNode extends OzNode {
 	@Override
 	@ExplodeLoop
 	public Object execute(VirtualFrame frame) {
-		MaterializedFrame capture = Truffle.getRuntime().createMaterializedFrame(ArrayUtils.EMPTY, capturedDescriptor);
+		MaterializedFrame capture = Truffle.getRuntime().createVirtualFrame(ArrayUtils.EMPTY, capturedDescriptor).materialize();
 		for (int i = 0; i < captureNodes.length; i++) {
 			captureNodes[i].executeWrite(frame, capture);
 		}

--- a/vm/src/org/mozartoz/truffle/nodes/local/CopyVariableToFrameNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/CopyVariableToFrameNode.java
@@ -10,18 +10,18 @@ import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 @NodeChild("capture")
-public abstract class WriteFrameToFrameNode extends OzNode {
+public abstract class CopyVariableToFrameNode extends OzNode {
 
-	public static WriteFrameToFrameNode create(OzNode readNode, FrameSlot to) {
-		return WriteFrameToFrameNodeGen.create(readNode, to, null);
+	public static CopyVariableToFrameNode create(OzNode readNode, FrameSlot to) {
+		return CopyVariableToFrameNodeGen.create(readNode, to, null);
 	}
 
 	public abstract Object executeWrite(VirtualFrame frame, MaterializedFrame capture);
 
 	@Child OzNode readNode;
-	protected FrameSlot to;
+	protected final FrameSlot to;
 
-	protected WriteFrameToFrameNode(OzNode readNode, FrameSlot to) {
+	protected CopyVariableToFrameNode(OzNode readNode, FrameSlot to) {
 		this.readNode = readNode;
 		this.to = to;
 	}

--- a/vm/src/org/mozartoz/truffle/nodes/local/CopyVariableToFrameNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/CopyVariableToFrameNode.java
@@ -12,23 +12,28 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 @NodeChild("capture")
 public abstract class CopyVariableToFrameNode extends OzNode {
 
-	public static CopyVariableToFrameNode create(OzNode readNode, FrameSlot to) {
-		return CopyVariableToFrameNodeGen.create(readNode, to, null);
+	public static CopyVariableToFrameNode create(OzNode readNode, FrameSlot slot) {
+		return CopyVariableToFrameNodeGen.create(readNode, slot, null);
 	}
 
 	public abstract Object executeWrite(VirtualFrame frame, MaterializedFrame capture);
 
 	@Child OzNode readNode;
-	protected final FrameSlot to;
 
-	protected CopyVariableToFrameNode(OzNode readNode, FrameSlot to) {
+	public final FrameSlot slot;
+
+	protected CopyVariableToFrameNode(OzNode readNode, FrameSlot slot) {
 		this.readNode = readNode;
-		this.to = to;
+		this.slot = slot;
+	}
+
+	public OzNode getReadNode() {
+		return readNode;
 	}
 
 	@Specialization
 	public Object write(VirtualFrame frame, MaterializedFrame capture,
-			@Cached("create(to)") WriteFrameSlotNode writeNode) {
+			@Cached("create(slot)") WriteFrameSlotNode writeNode) {
 		writeNode.executeWrite(capture, readNode.execute(frame));
 		return unit;
 	}

--- a/vm/src/org/mozartoz/truffle/nodes/local/ReadCapturedVariableNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/ReadCapturedVariableNode.java
@@ -5,14 +5,15 @@ import org.mozartoz.truffle.nodes.OzNode;
 import org.mozartoz.truffle.runtime.OzArguments;
 
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
-@ImportStatic(Options.class)
 public abstract class ReadCapturedVariableNode extends OzNode implements FrameSlotNode {
+	protected static final boolean CACHE_READ = Options.CACHE_READ;
+
+	public abstract Object executeRead(VirtualFrame frame);
 
 	final FrameSlot slot;
 	final int depth;

--- a/vm/src/org/mozartoz/truffle/nodes/local/ReadCapturedVariableNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/ReadCapturedVariableNode.java
@@ -1,31 +1,51 @@
 package org.mozartoz.truffle.nodes.local;
 
+import org.mozartoz.truffle.Options;
 import org.mozartoz.truffle.nodes.OzNode;
 import org.mozartoz.truffle.runtime.OzArguments;
 
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.ImportStatic;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
-public class ReadCapturedVariableNode extends OzNode implements FrameSlotNode {
+@ImportStatic(Options.class)
+public abstract class ReadCapturedVariableNode extends OzNode implements FrameSlotNode {
 
-	@Child CachingReadFrameSlotNode readFrameSlotNode;
-
+	final FrameSlot slot;
 	final int depth;
 
 	public ReadCapturedVariableNode(FrameSlot slot, int depth) {
-		this.readFrameSlotNode = CachingReadFrameSlotNodeGen.create(slot);
+		this.slot = slot;
 		this.depth = depth;
 	}
 
 	public FrameSlot getSlot() {
-		return readFrameSlotNode.getSlot();
+		return this.slot;
 	}
 
-	@Override
-	public Object execute(VirtualFrame frame) {
+	@Specialization(guards = "CACHE_READ")
+	protected Object readWithCache(VirtualFrame frame,
+			@Cached("createCachingReadNode(getSlot())") CachingReadFrameSlotNode readNode) {
 		Frame parentFrame = OzArguments.getParentFrame(frame, depth);
-		return readFrameSlotNode.executeRead(parentFrame);
+		return readNode.executeRead(parentFrame);
+	}
+
+	@Specialization(guards = "!CACHE_READ")
+	protected Object readWithoutCache(VirtualFrame frame,
+			@Cached("createReadNode(getSlot())") ReadFrameSlotNode readNode) {
+		Frame parentFrame = OzArguments.getParentFrame(frame, depth);
+		return readNode.executeRead(parentFrame);
+	}
+
+	protected ReadFrameSlotNode createReadNode(FrameSlot slot) {
+		return ReadFrameSlotNodeGen.create(slot);
+	}
+
+	protected CachingReadFrameSlotNode createCachingReadNode(FrameSlot slot) {
+		return CachingReadFrameSlotNodeGen.create(slot);
 	}
 
 }

--- a/vm/src/org/mozartoz/truffle/nodes/local/ReadCapturedVariableNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/ReadCapturedVariableNode.java
@@ -10,7 +10,7 @@ import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
-public abstract class ReadCapturedVariableNode extends OzNode implements FrameSlotNode {
+public abstract class ReadCapturedVariableNode extends OzNode {
 	protected static final boolean CACHE_READ = Options.CACHE_READ;
 
 	public abstract Object executeRead(VirtualFrame frame);
@@ -23,20 +23,16 @@ public abstract class ReadCapturedVariableNode extends OzNode implements FrameSl
 		this.depth = depth;
 	}
 
-	public FrameSlot getSlot() {
-		return this.slot;
-	}
-
 	@Specialization(guards = "CACHE_READ")
 	protected Object readWithCache(VirtualFrame frame,
-			@Cached("createCachingReadNode(getSlot())") CachingReadFrameSlotNode readNode) {
+			@Cached("createCachingReadNode(slot)") CachingReadFrameSlotNode readNode) {
 		Frame parentFrame = OzArguments.getParentFrame(frame, depth);
 		return readNode.executeRead(parentFrame);
 	}
 
 	@Specialization(guards = "!CACHE_READ")
 	protected Object readWithoutCache(VirtualFrame frame,
-			@Cached("createReadNode(getSlot())") ReadFrameSlotNode readNode) {
+			@Cached("createReadNode(slot)") ReadFrameSlotNode readNode) {
 		Frame parentFrame = OzArguments.getParentFrame(frame, depth);
 		return readNode.executeRead(parentFrame);
 	}

--- a/vm/src/org/mozartoz/truffle/nodes/local/ResetSlotsNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/ResetSlotsNode.java
@@ -1,0 +1,36 @@
+package org.mozartoz.truffle.nodes.local;
+
+import org.mozartoz.truffle.nodes.OzNode;
+
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+
+public class ResetSlotsNode extends OzNode {
+
+	final FrameSlot[] before;
+	@Child OzNode node;
+	final FrameSlot[] after;
+
+	public ResetSlotsNode(FrameSlot[] before, OzNode node, FrameSlot[] after) {
+		this.before = before;
+		this.node = node;
+		this.after = after;
+	}
+
+	@ExplodeLoop
+	private void resetSlots(VirtualFrame frame, FrameSlot[] slots) {
+		for (int i = 0; i < slots.length; i++) {
+			frame.setObject(slots[i], null);
+		}
+	}
+
+	@Override
+	public Object execute(VirtualFrame frame) {
+		resetSlots(frame, before);
+		Object result = node.execute(frame);
+		resetSlots(frame, after);
+		return result;
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/nodes/local/ResetSlotsNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/ResetSlotsNode.java
@@ -2,15 +2,16 @@ package org.mozartoz.truffle.nodes.local;
 
 import org.mozartoz.truffle.nodes.OzNode;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 
 public class ResetSlotsNode extends OzNode {
 
-	final FrameSlot[] before;
+	@CompilationFinal(dimensions = 1) FrameSlot[] before;
 	@Child OzNode node;
-	final FrameSlot[] after;
+	@CompilationFinal(dimensions = 1) FrameSlot[] after;
 
 	public ResetSlotsNode(FrameSlot[] before, OzNode node, FrameSlot[] after) {
 		this.before = before;

--- a/vm/src/org/mozartoz/truffle/nodes/local/WriteFrameSlotNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/WriteFrameSlotNode.java
@@ -12,6 +12,10 @@ import com.oracle.truffle.api.nodes.Node;
 @ImportStatic(FrameSlotKind.class)
 public abstract class WriteFrameSlotNode extends Node implements WriteNode, FrameSlotNode {
 
+	public static WriteFrameSlotNode create(FrameSlot slot) {
+		return WriteFrameSlotNodeGen.create(slot);
+	}
+
 	private final FrameSlot slot;
 
 	public WriteFrameSlotNode(FrameSlot slot) {

--- a/vm/src/org/mozartoz/truffle/nodes/local/WriteFrameToFrameNode.java
+++ b/vm/src/org/mozartoz/truffle/nodes/local/WriteFrameToFrameNode.java
@@ -1,0 +1,36 @@
+package org.mozartoz.truffle.nodes.local;
+
+import org.mozartoz.truffle.nodes.OzNode;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+
+@NodeChild("capture")
+public abstract class WriteFrameToFrameNode extends OzNode {
+
+	public static WriteFrameToFrameNode create(OzNode readNode, FrameSlot to) {
+		return WriteFrameToFrameNodeGen.create(readNode, to, null);
+	}
+
+	public abstract Object executeWrite(VirtualFrame frame, MaterializedFrame capture);
+
+	@Child OzNode readNode;
+	protected FrameSlot to;
+
+	protected WriteFrameToFrameNode(OzNode readNode, FrameSlot to) {
+		this.readNode = readNode;
+		this.to = to;
+	}
+
+	@Specialization
+	public Object write(VirtualFrame frame, MaterializedFrame capture,
+			@Cached("create(to)") WriteFrameSlotNode writeNode) {
+		writeNode.executeWrite(capture, readNode.execute(frame));
+		return unit;
+	}
+
+}

--- a/vm/src/org/mozartoz/truffle/runtime/OzThread.java
+++ b/vm/src/org/mozartoz/truffle/runtime/OzThread.java
@@ -34,6 +34,7 @@ public class OzThread implements Runnable {
 		return CURRENT_OZ_THREAD.get();
 	}
 
+	private final Coroutine original;
 	private final Coroutine coroutine;
 	private OzProc proc;
 	private final String procLocation;
@@ -43,6 +44,7 @@ public class OzThread implements Runnable {
 	private boolean raiseOnBlock = false;
 
 	private OzThread() {
+		original = null;
 		coroutine = (Coroutine) Coroutine.current();
 		proc = null;
 		procLocation = null;
@@ -54,8 +56,10 @@ public class OzThread implements Runnable {
 		this.proc = proc;
 		this.procLocation = proc.toString();
 		this.initialCall = initialCall;
+		this.original = (Coroutine) Coroutine.current();
 		this.coroutine = new Coroutine(this, 1024 * 1024); // 256 seems OK if we parse outside the coro
 		threadsCreated++;
+		Coroutine.yieldTo(coroutine);
 	}
 
 	private void setInitialOzThread() {
@@ -90,6 +94,9 @@ public class OzThread implements Runnable {
 
 	@Override
 	public void run() {
+		if (original != null) {
+			Coroutine.yieldTo(original);
+		}
 		setInitialOzThread();
 		threadsRunnable++;
 		try {

--- a/vm/src/org/mozartoz/truffle/translator/FrameSlotAndDepth.java
+++ b/vm/src/org/mozartoz/truffle/translator/FrameSlotAndDepth.java
@@ -1,7 +1,7 @@
 package org.mozartoz.truffle.translator;
 
 import org.mozartoz.truffle.nodes.OzNode;
-import org.mozartoz.truffle.nodes.local.ReadCapturedVariableNode;
+import org.mozartoz.truffle.nodes.local.ReadCapturedVariableNodeGen;
 import org.mozartoz.truffle.nodes.local.ReadLocalVariableNode;
 import org.mozartoz.truffle.nodes.local.WriteCapturedVariableNode;
 import org.mozartoz.truffle.nodes.local.WriteFrameSlotNodeGen;
@@ -34,7 +34,7 @@ public class FrameSlotAndDepth {
 		if (depth == 0) {
 			return new ReadLocalVariableNode(slot);
 		} else {
-			return new ReadCapturedVariableNode(slot, depth);
+			return ReadCapturedVariableNodeGen.create(slot, depth);
 		}
 	}
 

--- a/vm/src/org/mozartoz/truffle/translator/Loader.java
+++ b/vm/src/org/mozartoz/truffle/translator/Loader.java
@@ -16,6 +16,8 @@ import org.mozartoz.bootcompiler.transform.Namer;
 import org.mozartoz.bootcompiler.transform.OnStackMarking;
 import org.mozartoz.bootcompiler.transform.TailCallMarking;
 import org.mozartoz.bootcompiler.transform.Unnester;
+import org.mozartoz.bootcompiler.transform.VariableClearing;
+import org.mozartoz.bootcompiler.transform.VariableDeduplication;
 import org.mozartoz.truffle.Options;
 import org.mozartoz.truffle.nodes.DerefNode;
 import org.mozartoz.truffle.nodes.builtins.BuiltinsManager;
@@ -344,6 +346,11 @@ public class Loader {
 			new OnStackMarking().apply(program);
 		}
 		TailCallMarking.apply(program);
+		if (Options.FREE_SLOTS) {
+			assert Options.FRAME_FILTERING : "";
+			VariableDeduplication.apply(program);
+			VariableClearing.apply(program);
+		}
 
 		return program.rawCode();
 	}

--- a/vm/src/org/mozartoz/truffle/translator/Loader.java
+++ b/vm/src/org/mozartoz/truffle/translator/Loader.java
@@ -40,7 +40,6 @@ import org.mozartoz.truffle.runtime.Variable;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.FrameSlot;
-import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
@@ -154,6 +153,11 @@ public class Loader {
 		return base;
 	}
 
+	public void registerBase(DynamicObject base) {
+		assert this.base == null || this.base == base;
+		this.base = base;
+	}
+
 	private RootCallTarget parseBase() {
 		tick("enter parseBase");
 		Program program = BootCompiler.buildBaseEnvProgram(
@@ -231,7 +235,6 @@ public class Loader {
 				throw t;
 			}
 			tick("deserialized Main");
-			base = getBaseFromMain(main);
 		} else {
 			eagerLoad = true;
 			try {
@@ -280,13 +283,6 @@ public class Loader {
 				Arity.build("import", "Boot"),
 				BuiltinsManager.getBootModule("Boot_Boot"));
 		return execute(ApplyFunctor.apply(language, initFunctor, imports, "Init.apply"));
-	}
-
-	private DynamicObject getBaseFromMain(OzProc main) {
-		MaterializedFrame topFrame = OzArguments.getParentFrame(main.declarationFrame);
-		FrameSlot baseSlot = topFrame.getFrameDescriptor().getSlots().get(0);
-		assert baseSlot.getIdentifier().toString().contains("<Base>");
-		return (DynamicObject) topFrame.getValue(baseSlot);
 	}
 
 	// Shutdown

--- a/vm/src/org/mozartoz/truffle/translator/Translator.java
+++ b/vm/src/org/mozartoz/truffle/translator/Translator.java
@@ -113,7 +113,7 @@ import org.mozartoz.truffle.nodes.local.InitializeArgNode;
 import org.mozartoz.truffle.nodes.local.InitializeTmpNode;
 import org.mozartoz.truffle.nodes.local.InitializeVarNode;
 import org.mozartoz.truffle.nodes.local.ResetSlotsNode;
-import org.mozartoz.truffle.nodes.local.WriteFrameToFrameNode;
+import org.mozartoz.truffle.nodes.local.CopyVariableToFrameNode;
 import org.mozartoz.truffle.nodes.pattern.PatternMatchConsNodeGen;
 import org.mozartoz.truffle.nodes.pattern.PatternMatchDynamicArityNodeGen;
 import org.mozartoz.truffle.nodes.pattern.PatternMatchEqualNode;
@@ -418,11 +418,11 @@ public class Translator {
 			OzRootNode rootNode = new OzRootNode(language, sourceSection, identifier, environment.frameDescriptor, procBody, arity, forceSplitting);
 
 			if (Options.FRAME_FILTERING) {
-				WriteFrameToFrameNode[] captureNodes = new WriteFrameToFrameNode[environment.capturedVariables.getSize()];
+				CopyVariableToFrameNode[] captureNodes = new CopyVariableToFrameNode[environment.capturedVariables.getSize()];
 				int j = 0;
 				for (FrameSlot dst : environment.capturedVariables.getSlots()) {
 					FrameSlotAndDepth src = environment.parent.findAndExtractVariable((String) dst.getIdentifier());
-					captureNodes[j] = WriteFrameToFrameNode.create(src.createReadNode(), dst);
+					captureNodes[j] = CopyVariableToFrameNode.create(src.createReadNode(), dst);
 					j++;
 				}
 				return t(procExpression, new ProcDeclarationAndExtractionNode(rootNode.toCallTarget(), environment.capturedVariables, captureNodes));


### PR DESCRIPTION
This pull request aims at reworking the frame mechanism.

First, the captured environment is stored within a MaterializedFrame associated to the procedure. In this mode, there is thus no more hierarchy of frames. However, the captured environment places itself at the "parent frame" position in the arguments. It allows to reuse the old mechanism with depth of at most 1.
As it opened opportunities to free local variables as soon as they are not used anymore (rather than when leaving the local node for instance) this has also been implemented and is believed to work in most cases, while it may forget to clear one or the other within try-catch blocks. (also in case of a NoElse branch)